### PR TITLE
Archiving html results

### DIFF
--- a/tests/unittests/test_tests_client.py
+++ b/tests/unittests/test_tests_client.py
@@ -276,7 +276,7 @@ def test_test_runner_usage_err(mocker, capsys):
     assert pytest_exit.value.code == 1
 
 
-def test__set_test_parameters(loginfo, logwarn):
+def test__set_test_parameters(loginfo, logwarn, mocker):
     """Validate _set_test_parameters with various values"""
 
     # pylint: disable-next=fixme
@@ -289,6 +289,8 @@ def test__set_test_parameters(loginfo, logwarn):
         "tests/unittests/fixtures/defs_set_test_params.yaml", DUTS
     )
 
+    mocker.patch("vane.tests_client.TestsClient.now", return_value="-08-01-2023 15:18:22")
+
     # Run _set_test_parameters
     client._set_test_parameters()
 
@@ -299,7 +301,10 @@ def test__set_test_parameters(loginfo, logwarn):
         call("Initialize test parameter values"),
         call("Run the following tests: All"),
         call("Running All test cases."),
-        call("Set HTML report name to: --html=tests/unittests/fixtures/reports/report.html"),
+        call(
+            "Set HTML report name to: --html=tests/unittests/fixtures/reports/"
+            "report-08-01-2023 15:18:22.html"
+        ),
         call("Set --json report name to: --json=tests/unittests/fixtures/reports/report.json"),
     ]
     loginfo.assert_has_calls(loginfo_calls, any_order=True)

--- a/vane/tests_client.py
+++ b/vane/tests_client.py
@@ -47,6 +47,7 @@ import sys
 import shutil
 
 import configparser
+from datetime import datetime
 import pytest
 import yaml
 
@@ -246,7 +247,9 @@ class TestsClient:
         """Set html_report for test run"""
 
         html_report = self.data_model["parameters"].get("html_report")
-        html_name = f"--html={html_report}.html"
+        dt_string = self.now()
+        html_title = html_report + dt_string
+        html_name = f"--html={html_title}.html"
         list_out = [x for x in self.test_parameters if "--html" in x]
 
         if html_report and html_name not in self.test_parameters:
@@ -389,3 +392,8 @@ class TestsClient:
             # Deleting a non-empty folder
             shutil.rmtree(test_results_dir, ignore_errors=True)
             logging.info(f"Deleted {test_results_dir} directory successfully")
+
+    def now(self):
+        """Return current date and time"""
+
+        return (datetime.now()).strftime("-%m-%d-%Y %H:%M:%S")


### PR DESCRIPTION
# Please include a summary of the changes

* tests_client.py: Changed the logic to generate .html files with different name (time stamp) so as to not overwrite existing .html file. Added a now method to give current time.
* test_tests_client.py: Refactored the test case accordingly

# Any specific logic/part of code you need extra attention on

The naming of the reports

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/376

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
    
## New feature

All test cases pass:

<img width="1300" alt="Screenshot 2023-08-02 at 12 59 20 PM" src="https://github.com/aristanetworks/vane/assets/123415500/0eae8477-b190-4d46-8b4e-1b5ad65412ce">

The html results do not get deleted after a new run
    
<img width="310" alt="Screenshot 2023-08-02 at 12 59 53 PM" src="https://github.com/aristanetworks/vane/assets/123415500/5d987d64-c293-4f23-8b53-4ba9840d372e">

# CI pipeline result

- - [X] Pass
- - [ ] Fail
