### PR TITLE
Moved now() to utils.py and changed the test function & test_step_client accordingly

### DIFF
--- a/tests/unittests/test_tests_step_client.py
+++ b/tests/unittests/test_tests_step_client.py
@@ -114,7 +114,7 @@ def test_parse_file(loginfo, logdebug, mocker):
 
     # Set datetime to a known value
     mocker.patch(
-        "vane.test_step_client.TestStepClient.now",
+        "vane.utils.now",
         return_value="01/01/2023 00:00:00",
     )
     mocker_object_one = mocker.patch("vane.test_step_client.TestStepClient.output_json")
@@ -140,7 +140,7 @@ def test_parse_file_no_steps(loginfo, logdebug, mocker):
 
     # Set datetime to a known value
     mocker.patch(
-        "vane.test_step_client.TestStepClient.now",
+        "vane.utils.now",
         return_value="01/01/2023 00:00:00",
     )
     mocker_object_one = mocker.patch("vane.test_step_client.TestStepClient.output_json")

--- a/tests/unittests/test_tests_step_client.py
+++ b/tests/unittests/test_tests_step_client.py
@@ -114,7 +114,7 @@ def test_parse_file(loginfo, logdebug, mocker):
 
     # Set datetime to a known value
     mocker.patch(
-        "vane.utils.now",
+        "vane.test_step_client.now",
         return_value="01/01/2023 00:00:00",
     )
     mocker_object_one = mocker.patch("vane.test_step_client.TestStepClient.output_json")
@@ -140,7 +140,7 @@ def test_parse_file_no_steps(loginfo, logdebug, mocker):
 
     # Set datetime to a known value
     mocker.patch(
-        "vane.utils.now",
+        "vane.test_step_client.now",
         return_value="01/01/2023 00:00:00",
     )
     mocker_object_one = mocker.patch("vane.test_step_client.TestStepClient.output_json")

--- a/vane/test_step_client.py
+++ b/vane/test_step_client.py
@@ -35,9 +35,9 @@ import os
 import json
 import re
 from pathlib import Path
-import datetime
 from mdutils.mdutils import MdUtils
 from vane.vane_logging import logging
+from vane import utils
 
 
 class TestStepClient:
@@ -79,11 +79,6 @@ class TestStepClient:
             logging.debug(f"Discovered test files: {test_files} for parsing")
             self.parse_file(test_files)
 
-    def now(self):
-        """Return current date and time"""
-
-        return (datetime.datetime.now()).strftime("%d/%m/%Y %H:%M:%S")
-
     def parse_file(self, test_files):
         """Parses Files for Test Steps & Definitions
 
@@ -104,7 +99,7 @@ class TestStepClient:
             comments = [x.strip() for x in comments]
             if not comments:
                 comments.append("N/a no Test Steps found")
-            comments.insert(0, self.now())
+            comments.insert(0, utils.now())
 
             logging.debug(f"Create JSON and MD files for {test_file} using {comments}")
             self.output_json({test_file: comments})

--- a/vane/test_step_client.py
+++ b/vane/test_step_client.py
@@ -37,7 +37,7 @@ import re
 from pathlib import Path
 from mdutils.mdutils import MdUtils
 from vane.vane_logging import logging
-from vane import utils
+from vane.utils import now
 
 
 class TestStepClient:
@@ -99,7 +99,7 @@ class TestStepClient:
             comments = [x.strip() for x in comments]
             if not comments:
                 comments.append("N/a no Test Steps found")
-            comments.insert(0, utils.now())
+            comments.insert(0, now())
 
             logging.debug(f"Create JSON and MD files for {test_file} using {comments}")
             self.output_json({test_file: comments})

--- a/vane/utils.py
+++ b/vane/utils.py
@@ -34,6 +34,7 @@ Collection of misc functions that dont fit anywhere else but are still required.
 
 import sys
 import collections
+import datetime
 
 
 def make_iterable(value):
@@ -107,3 +108,9 @@ def remove_comments(input_string):
 
     output_string = "\n".join(output_string_arr)
     return output_string
+
+
+def now():
+    """Return current date and time"""
+
+    return (datetime.datetime.now()).strftime("%d/%m/%Y %H:%M:%S")

--- a/vane/utils.py
+++ b/vane/utils.py
@@ -113,4 +113,4 @@ def remove_comments(input_string):
 def now():
     """Return current date and time"""
 
-    return (datetime.datetime.now()).strftime("%d/%m/%Y %H:%M:%S")
+    return (datetime.datetime.now()).strftime("%d-%m-%Y %H:%M:%S")


### PR DESCRIPTION
# Please include a summary of the changes

* utils.py : Added now() function
* test_step_client : removed now() and referred to the now() in utils.py
* test_test_step_client.py : changed the mocking of now()

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/455

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

tests for test_step_client pass as before
    
<img width="1295" alt="Screenshot 2023-08-23 at 7 07 22 AM" src="https://github.com/aristanetworks/vane/assets/123415500/70b0b200-dd4b-408e-9391-6f9415ba1c36">

# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
 
