### PR TITLE
Archiving HTML results

### DIFF
--- a/tests/unittests/test_tests_client.py
+++ b/tests/unittests/test_tests_client.py
@@ -276,7 +276,7 @@ def test_test_runner_usage_err(mocker, capsys):
     assert pytest_exit.value.code == 1
 
 
-def test__set_test_parameters(loginfo, logwarn):
+def test__set_test_parameters(loginfo, logwarn, mocker):
     """Validate _set_test_parameters with various values"""
 
     # pylint: disable-next=fixme
@@ -289,6 +289,8 @@ def test__set_test_parameters(loginfo, logwarn):
         "tests/unittests/fixtures/defs_set_test_params.yaml", DUTS
     )
 
+    mocker.patch("vane.utils.now", return_value="-08-01-2023 15:18:22")
+
     # Run _set_test_parameters
     client._set_test_parameters()
 
@@ -299,7 +301,10 @@ def test__set_test_parameters(loginfo, logwarn):
         call("Initialize test parameter values"),
         call("Run the following tests: All"),
         call("Running All test cases."),
-        call("Set HTML report name to: --html=tests/unittests/fixtures/reports/report.html"),
+        call(
+            "Set HTML report name to: --html=tests/unittests/fixtures/reports/"
+            "report-08-01-2023 15:18:22.html"
+        ),
         call("Set --json report name to: --json=tests/unittests/fixtures/reports/report.json"),
     ]
     loginfo.assert_has_calls(loginfo_calls, any_order=True)

--- a/tests/unittests/test_tests_client.py
+++ b/tests/unittests/test_tests_client.py
@@ -289,7 +289,7 @@ def test__set_test_parameters(loginfo, logwarn, mocker):
         "tests/unittests/fixtures/defs_set_test_params.yaml", DUTS
     )
 
-    mocker.patch("vane.utils.now", return_value="-08-01-2023 15:18:22")
+    mocker.patch("vane.tests_client.now", return_value="-08-01-2023 15:18:22")
 
     # Run _set_test_parameters
     client._set_test_parameters()

--- a/tests/unittests/test_tests_client.py
+++ b/tests/unittests/test_tests_client.py
@@ -289,7 +289,7 @@ def test__set_test_parameters(loginfo, logwarn, mocker):
         "tests/unittests/fixtures/defs_set_test_params.yaml", DUTS
     )
 
-    mocker.patch("vane.tests_client.now", return_value="-08-01-2023 15:18:22")
+    mocker.patch("vane.tests_client.now", return_value="-08-01-2023 15:18:21")
 
     # Run _set_test_parameters
     client._set_test_parameters()
@@ -303,7 +303,7 @@ def test__set_test_parameters(loginfo, logwarn, mocker):
         call("Running All test cases."),
         call(
             "Set HTML report name to: --html=tests/unittests/fixtures/reports/"
-            "report-08-01-2023 15:18:22.html"
+            "report-08-01-2023 15:18:21.html"
         ),
         call("Set --json report name to: --json=tests/unittests/fixtures/reports/report.json"),
     ]

--- a/vane/tests_client.py
+++ b/vane/tests_client.py
@@ -53,7 +53,8 @@ import yaml
 from jinja2 import Template, Undefined
 from pytest import ExitCode
 from vane.vane_logging import logging
-from vane import tests_tools, utils
+from vane import tests_tools
+from vane.utils import now
 
 
 class NullUndefined(Undefined):
@@ -246,7 +247,7 @@ class TestsClient:
         """Set html_report for test run"""
 
         html_report = self.data_model["parameters"].get("html_report")
-        dt_string = utils.now()
+        dt_string = now()
         html_title = html_report + dt_string
         html_name = f"--html={html_title}.html"
         list_out = [x for x in self.test_parameters if "--html" in x]

--- a/vane/tests_client.py
+++ b/vane/tests_client.py
@@ -53,7 +53,7 @@ import yaml
 from jinja2 import Template, Undefined
 from pytest import ExitCode
 from vane.vane_logging import logging
-from vane import tests_tools
+from vane import tests_tools, utils
 
 
 class NullUndefined(Undefined):
@@ -246,7 +246,9 @@ class TestsClient:
         """Set html_report for test run"""
 
         html_report = self.data_model["parameters"].get("html_report")
-        html_name = f"--html={html_report}.html"
+        dt_string = utils.now()
+        html_title = html_report + dt_string
+        html_name = f"--html={html_title}.html"
         list_out = [x for x in self.test_parameters if "--html" in x]
 
         if html_report and html_name not in self.test_parameters:

--- a/vane/utils.py
+++ b/vane/utils.py
@@ -34,6 +34,7 @@ Collection of misc functions that dont fit anywhere else but are still required.
 
 import sys
 import collections
+import datetime
 
 
 def make_iterable(value):
@@ -107,3 +108,9 @@ def remove_comments(input_string):
 
     output_string = "\n".join(output_string_arr)
     return output_string
+
+
+def now():
+    """Return current date and time"""
+
+    return (datetime.datetime.now()).strftime("%d-%m-%Y %H:%M:%S")


### PR DESCRIPTION
# Please include a summary of the changes

* tests_client.py: Changed the logic to generate .html files with different name (time stamp) so as to not overwrite existing .html file.
* test_tests_client.py: Refactored the test case accordingly

# Any specific logic/part of code you need extra attention on

The naming of the reports

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/376

# List/Attach any dependencies/past issues that are required for this change/provide context

https://github.com/aristanetworks/vane/pull/457 **SHOULD BE MERGED BEFORE** THIS PR

as it introduces the now() method in utils.py


# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
    
## New feature

All test cases pass:

<img width="1304" alt="Screenshot 2023-08-23 at 8 20 15 AM" src="https://github.com/aristanetworks/vane/assets/123415500/d94abd1b-3f38-46dc-9a4d-0831e945e776">


The html results do not get deleted after a new run
    
<img width="295" alt="Screenshot 2023-08-23 at 8 19 41 AM" src="https://github.com/aristanetworks/vane/assets/123415500/d6a4df75-4824-4ad0-a4f9-6cb3f0e08f7c">

# CI pipeline result

- - [X] Pass
- - [ ] Fail
