### PR TITLE
Add pytest.ini to vane-data folder in CVP container for RPM

### DIFF
--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - example-rpm-package-testing-branch
+      - gar-issue-470
 
 # Variables
 env:

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -16,7 +16,6 @@ on:
   push:
     branches:
       - example-rpm-package-testing-branch
-      - gar-issue-470
 
 # Variables
 env:

--- a/resources/vane-bashrc
+++ b/resources/vane-bashrc
@@ -54,6 +54,10 @@ if [ -n "$VANE_CVP" ]; then
   if [ -d "/vane-data" ] && [ ! -d "/vane-data/nrfu_tests" ]; then
     cp -r /project/nrfu_tests /vane-data/.
   fi
+  # Copy pytest.ini to the vane-data directory
+  if [ -d "/vane-data" ] && [ ! -f "/vane-data/pytest.ini" ]; then
+    cp -r /project/pytest.ini /vane-data/.
+  fi
 
   # Check the stty size result
   #   Avoids instances where unusual screen wrapping occurs while typing a command, and the


### PR DESCRIPTION
# Please include a summary of the changes

* resources/vane-bashrc - copy pytest.ini from vane project folder to /vane-data

# Any specific logic/part of code you need extra attention on

Logic is the same as the preceding blocks in the container bashrc, except is checking for a file instead of directory, and copies the pytest.ini file if not found.

# Include the Issue number and link

Fixes #470 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

Built a new rpm package by temporarily adding the working branch to the workflow pipeline: https://github.com/aristanetworks/vane/actions/runs/5979088327
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
