### PR TITLE
issue-449: Automated test case for Convert Pytest-CVP Power Supply Voltage test case to Vane

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -294,7 +294,7 @@
     - name: test_system_hardware_power_supply_voltage_status
       description: Test case for verification of system power supply voltage sensor status on the device.
       test_id: NRFU6.10
-      show_cmd: null # Show command is added in test case file as need to skip test execution devices based on platform
+      show_cmd: null # Show command is added in the test case file as need to skip test execution devices based on platform
       expected_output: null # Expected output is formed inside a test case file dynamically.
       test_criteria: Status of all power supply voltage sensors should be 'Ok'
       report_style: modern

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -291,11 +291,12 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_system_hardware_power_supply_voltage_status
+      description: Test case for verification of system power supply voltage sensor status on the device.
       test_id: NRFU6.10
-      show_cmd: null
-      expected_output: null
+      show_cmd: null # Show command is added in test case file as need to skip test execution devices based on platform
+      expected_output: null # Expected output is formed inside a test case file dynamically.
+      test_criteria: Status of all power supply voltage sensors should be 'Ok'
       report_style: modern
       criteria: names
       filter:
@@ -305,7 +306,3 @@
       test_id: NRFU6.11
       show_cmd: null
       expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -306,3 +306,7 @@
       test_id: NRFU6.11
       show_cmd: null
       expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -273,3 +273,6 @@
       test_id: NRFU6.11
       show_cmd: null
       expected_output: null
+      report_style: modern
+      criteria: {{ global_dut_filter.criteria }}
+      filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -259,11 +259,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_system_hardware_power_supply_voltage_status
+      description: Test case for verification of system power supply voltage sensor status on the device.
       test_id: NRFU6.10
       show_cmd: null
       expected_output: null
+      test_criteria: Status of all power supply voltage sensors should be 'Ok'
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
@@ -272,6 +273,3 @@
       test_id: NRFU6.11
       show_cmd: null
       expected_output: null
-      report_style: modern
-      criteria: {{ global_dut_filter.criteria }}
-      filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_hardware_power_supply_voltage_status.py
+++ b/nrfu_tests/test_hardware_power_supply_voltage_status.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test case for verification of system power supply voltage sensor status on the device.
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.system
+class PowerSupplyVoltageTests:
+    """
+    Test case for verification of system power supply voltage sensor status on the device.
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_system_hardware_power_supply_voltage_status"]["duts"]
+    test_ids = dut_parameters["test_system_hardware_power_supply_voltage_status"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_system_hardware_power_supply_voltage_status(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of system power supply voltage sensor status on the device.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {"power_supply_voltage_sensors": {}}
+        tops.expected_output = {"power_supply_voltage_sensors": {}}
+
+        # Output message if test result is passed
+        tops.output_msg = "Status of all power supply voltage sensors is 'Ok'"
+
+        try:
+            """
+            TS: Running 'show version' command on device and skipping the test case
+            for device if platform is vEOS.
+            """
+            version_output = dut["output"]["show version"]["json"]
+            logger.info(
+                "On device %s, output of show version command is:\n%s\n",
+                tops.dut_name,
+                version_output,
+            )
+            self.output += f"\nOutput of {tops.show_cmd} command is:\n{version_output}\n"
+
+            # Skipping testcase if device is vEOS.
+            if "vEOS" in version_output.get("modelName"):
+                pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
+
+            """
+            TS: Running `show system environment power voltage` command on the device and
+            verifying status for all power supply voltage sensor should be 'OK'.
+            """
+            power_supply_cmd = "show system environment power voltage"
+            voltage_cmd_output = tops.run_show_cmds([power_supply_cmd])
+            logger.info(
+                "On device %s, output of %s command is: \n%s\n",
+                tops.dut_name,
+                power_supply_cmd,
+                voltage_cmd_output,
+            )
+            self.output += f"\nOutput of {power_supply_cmd} command is:\n{voltage_cmd_output}\n"
+            voltage_sensors = voltage_cmd_output[0]["result"].get("voltageSensors")
+
+            # Collecting power supply sensors from list of sensor
+            power_voltage_sensor = [
+                {sensor: sensor_data}
+                for sensor, sensor_data in voltage_sensors.items()
+                if "PowerSupply" in sensor
+            ]
+            assert (
+                power_voltage_sensor
+            ), "Power supply voltage sensor details are not found on the device."
+
+            # Updating actual and expected state of power supply sensor
+            for voltage_sensor in power_voltage_sensor:
+                for sensor, sensor_data in voltage_sensor.items():
+                    tops.expected_output["power_supply_voltage_sensors"].update({sensor: "ok"})
+                    tops.actual_output["power_supply_voltage_sensors"].update(
+                        {sensor: sensor_data.get("status")}
+                    )
+
+            # Forming output message in case of test case failure
+            if tops.output_msg != tops.expected_output:
+                unhealthy_power_supplies = []
+                for power_supply_sensor, expected_status in tops.expected_output[
+                    "power_supply_voltage_sensors"
+                ].items():
+                    actual_status = tops.actual_output["power_supply_voltage_sensors"][
+                        power_supply_sensor
+                    ]
+                    if actual_status == expected_status:
+                        continue
+                    unhealthy_power_supplies.append(f"{power_supply_sensor} - {actual_status}")
+                if unhealthy_power_supplies:
+                    power_supply_status = "\n".join(unhealthy_power_supplies)
+                    tops.output_msg = (
+                        "Status for following power supply voltage sensors is not found as 'OK'"
+                        f" and current status on them is found as follows:\n{power_supply_status}"
+                    )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_system_hardware_power_supply_voltage_status)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes

test_definition.yaml: Updated test def with testcase NRFU6.10.
test_definition.yaml.j2: Updated J2 with testcase NRFU6.10.
master_def.yaml: Updated master def with testcase NRFU6.10.
test_security_rp_ssh_access_list.py: Added python file for testcase NRFU6.10.

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on
This testcase will verify the power voltage sensor status in  `show system environment power voltage` command output if power supply sensors are not found test case will fail with assertion error. If device platform is vEOS the test case will skip.

# Include the Issue number and link
#449 
Make sure to link the issue in the github PR UI 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU testcases)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Unit test cases:
1. If power  supply  voltage sensor are Ok - test case should pass  - Passed. 
**j2 :** 
   [report_2309141545.docx](https://github.com/aristanetworks/vane/files/12607862/report_2309141545.docx)

     **without j2:** 
  [report_2309141543.docx](https://github.com/aristanetworks/vane/files/12607866/report_2309141543.docx)

Note: For all failure cases hardcoded output is used.

2. If device platform is vEOS test case should be skipped. - Skipped (Docx report doesn't contain output. [report_2309141547.docx](https://github.com/aristanetworks/vane/files/12607872/report_2309141547.docx)

3. If power supply voltage sensors are not found in output - test case should fail - Failed.
[report_2309141552.docx](https://github.com/aristanetworks/vane/files/12607880/report_2309141552.docx)

4. If Power supply voltage status is not 'ok' - test case should fail- failed.
[report_2309141549.docx](https://github.com/aristanetworks/vane/files/12607887/report_2309141549.docx)

**HTML reports:**
[HTML reports.zip](https://github.com/aristanetworks/vane/files/12607897/HTML.reports.zip)


## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
