### PR TITLE
issue_420: Converted Pytest-CVP NTP test case to Vane #420

### DIFF
--- a/nrfu_tests/test_base_services_ntp_association.py
+++ b/nrfu_tests/test_base_services_ntp_association.py
@@ -5,16 +5,16 @@
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane import tests_tools
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
 @pytest.mark.base_services
-class NtpAssociationsTests:
+class NtpAssocitionsTests:
     """Testcases for verification of NTP association functionality"""
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -35,7 +35,7 @@ class NtpAssociationsTests:
             "primary_ntp_association": "Not found",
             "secondary_ntp_association": "Not found",
         }
-        # Forming output message if test result is pass
+        # Forming an output message if a test result is pass
         tops.output_msg = (
             "NTP server is configured on the device. Primary and secondary NTP association is"
             " correct on the device."
@@ -46,11 +46,8 @@ class NtpAssociationsTests:
             TS: Running `show ntp status` on device and verifying the NTP is configured.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
             )
             self.output = f"Output of {tops.show_cmd} command is: \n{output}\n"
 
@@ -65,11 +62,8 @@ class NtpAssociationsTests:
             primary and secondary NTP association is correct on the host.
             """
             output = tops.run_show_cmds([ntp_association_cmd])
-            logger.info(
-                "On device %s output of %s command is:\n%s\n",
-                tops.dut_name,
-                ntp_association_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name} output of {ntp_association_cmd} command is:\n{output}\n"
             )
             self.output += f"Output of {ntp_association_cmd} command is: \n{output}"
             ntp_associations = output[0]["result"].get("peers")
@@ -81,7 +75,7 @@ class NtpAssociationsTests:
                 elif ntp_associations[peer].get("condition") == "candidate":
                     tops.actual_output["secondary_ntp_association"] = "candidate"
 
-            # Forming output message if test result is fail
+            # Forming an output message if a test result is fail
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = ""
                 not_primary_ntp_association = (
@@ -103,10 +97,9 @@ class NtpAssociationsTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excp:
             tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s: Error occurred while running testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}: Error occurred while running testcase"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_base_services_ntp_association.py
+++ b/nrfu_tests/test_base_services_ntp_association.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+""" Test case to verify that 2 NTP clocks(a peer and a candidate) are locked on the device."""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.base_services
+class NtpAssociationsTests:
+    """Testcases for verification of NTP association functionality"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_ntp_clocks"]["duts"]
+    test_ids = dut_parameters["test_ntp_clocks"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_ntp_clocks(self, dut, tests_definitions):
+        """
+        TD: Test case to verify that 2 NTP clocks(a peer and a candidate) are locked on the device
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {
+            "primary_ntp_association": "Not found",
+            "secondary_ntp_association": "Not found",
+        }
+        # Forming output message if test result is pass
+        tops.output_msg = (
+            "NTP server is configured on the device. Primary and secondary NTP association is"
+            " correct on the device."
+        )
+
+        try:
+            """
+            TS: Running `show ntp status` on device and verifying the NTP is configured.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output = f"Output of {tops.show_cmd} command is: \n{output}\n"
+
+            # Skipping testcase if NTP server is not configured on DUT.
+            if output.get("status") == "disabled":
+                pytest.skip(f"NTP server is not configured on device {tops.dut_name}.")
+
+            ntp_association_cmd = "show ntp associations"
+
+            """
+            TS: Running `show ntp associations` on device and verifying that the
+            primary and secondary NTP association is correct on the host.
+            """
+            output = tops.run_show_cmds([ntp_association_cmd])
+            logger.info(
+                "On device %s output of %s command is:\n%s\n",
+                tops.dut_name,
+                ntp_association_cmd,
+                output,
+            )
+            self.output += f"Output of {ntp_association_cmd} command is: \n{output}"
+            ntp_associations = output[0]["result"].get("peers")
+            assert ntp_associations, "NTP association details are not collected."
+
+            for peer in ntp_associations:
+                if ntp_associations[peer].get("condition") == "sys.peer":
+                    tops.actual_output["primary_ntp_association"] = "sys.peer"
+                elif ntp_associations[peer].get("condition") == "candidate":
+                    tops.actual_output["secondary_ntp_association"] = "candidate"
+
+            # Forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = ""
+                not_primary_ntp_association = (
+                    tops.actual_output["primary_ntp_association"]
+                    != tops.expected_output["primary_ntp_association"]
+                )
+                not_secondary_ntp_association = (
+                    tops.actual_output["secondary_ntp_association"]
+                    != tops.expected_output["secondary_ntp_association"]
+                )
+                if not_primary_ntp_association and not_secondary_ntp_association:
+                    tops.output_msg += (
+                        "Primary and Secondary NTP associations are not found on the device.\n"
+                    )
+                elif not_primary_ntp_association:
+                    tops.output_msg += "Primary NTP association is not found on the device.\n"
+                elif not_secondary_ntp_association:
+                    tops.output_msg += "Secondary NTP association is not found on the device."
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excp:
+            tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error occurred while running testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_ntp_clocks)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -9,12 +9,15 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_ntp_clocks
+      description: Test case to verify that 2 NTP clocks(a peer and a candidate) are locked on the device.
       test_id: NRFU1.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show ntp status
+      expected_output:
+        primary_ntp_association: sys.peer
+        secondary_ntp_association: candidate
+      test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern, If a report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -8,11 +8,14 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_ntp_clocks
+      description: Test case to verify that 2 NTP clocks(a peer and a candidate) are locked on the device.
       test_id: NRFU1.2
-      show_cmd: null
-      expected_output: null
+      show_cmd: show ntp status
+      expected_output:
+        primary_ntp_association: sys.peer
+        secondary_ntp_association: candidate
+      test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}


### PR DESCRIPTION
# Please include a summary of the changes
Converted test_base_services_ntp_association.py as per the vane style guide along with that updated following files.
test_definition.yaml: Updated test def with testcase NRFU1.2
test_definition.yaml.j2: Updated J2 with testcase NRFU1.2.
nrfu_tests/test_base_services_ntp_association.py: Added testcase for NRFU1.2.

# Any specific logic/part of code you need extra attention on
Verified primary and secondary associations using the output of `show ntp associations` command, if NTP server is not configured testcase will skip.

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/420


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU testcases)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
   Unit tests
   - Tested the NTP server is configured and primary and secondary association is present.
       Reports:
       [report_ntp_pass.docx](https://github.com/aristanetworks/vane/files/12608197/report_ntp_pass.docx)


   - Tested for NTP server is not configured
      Reports:
     [report_ntp_not_configured.docx](https://github.com/aristanetworks/vane/files/12488676/report_ntp_not_configured.docx)


 -  Tested for NTP association details are not found**(Tested with hardcoded output)**
    Reports:
    [report_ntp_association_empty.docx](https://github.com/aristanetworks/vane/files/12488679/report_ntp_association_empty.docx)



- Tested for NTP  primary and secondary association details are not present. **(Tested with hardcoded output)**
    Reports:
    [report_both_ntp_association_not_found.docx](https://github.com/aristanetworks/vane/files/12488685/report_both_ntp_association_not_found.docx)


- Tested for NTP secondary association details are not present **(Tested with hardcoded output)**
  Reports:
  [report_sec_NTP_association_not_found.docx](https://github.com/aristanetworks/vane/files/12488687/report_sec_NTP_association_not_found.docx)

   
HTML reports for all mentioned unit testcases
[ntp.zip](https://github.com/aristanetworks/vane/files/12608198/ntp.zip)


   

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
