### PR TITLE
issue_422: Converted Pytest-CVP TACACS test case to Vane #422

### DIFF
--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -61,19 +61,6 @@ class TacacsServersTests:
 
             for tacacs_server in tacacs_servers:
                 tacacs_hostname = tacacs_server.get("serverInfo").get("hostname")
-                tops.expected_output["tacacs_servers_info"].update(
-                    {
-                        tacacs_hostname: {
-                            "received_errors": 0,
-                            "connection_disconnects": 0,
-                            "dns_errors": 0,
-                            "send_timeouts": 0,
-                            "connection_timeouts": 0,
-                            "connection_failures": 0,
-                            "received_timeouts": 0,
-                        }
-                    }
-                )
                 tops.actual_output["tacacs_servers_info"].update(
                     {
                         tacacs_hostname: {
@@ -86,6 +73,14 @@ class TacacsServersTests:
                             "received_timeouts": tacacs_server.get("receiveTimeouts"),
                         }
                     }
+                )
+
+                # Forming expected output
+                expected_output = dict.fromkeys(
+                    tops.actual_output.get("tacacs_servers_info").get(tacacs_hostname).keys(), 0
+                )
+                tops.expected_output["tacacs_servers_info"].update(
+                    {tacacs_hostname: expected_output}
                 )
 
                 # Forming output message if the test result fails.

--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Arista Networks, Inc.  All rights reserved.
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
@@ -54,43 +54,43 @@ class TacacsServersTests:
                 tops.show_cmd,
                 output,
             )
-            self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
-            tacacs_servers = output.get('tacacsServers')
+            self.output += f"Output of {tops.show_cmd} command is: \n{output}"
+            tacacs_servers = output.get("tacacsServers")
 
             # Skipping testcase if TACACS servers are not configured.
             if not tacacs_servers:
-                pytest.skip(f"No TACACS servers are configured on {tops.dut_name}.")
-            else:
-                for tacacs_server in tacacs_servers:
-                    tacacs_hostname = tacacs_server.get("serverInfo").get("hostname")
-                    tops.expected_output["tacacs_servers_info"].update(
-                        {
-                            tacacs_hostname: {
-                                "received_errors": 0,
-                                "connection_disconnects": 0,
-                                "dns_errors": 0,
-                                "send_timeouts": 0,
-                                "connection_timeouts": 0,
-                                "connection_failures": 0,
-                                "received_timeouts": 0,
-                            }
+                pytest.skip(f"TACACS servers are not configured on {tops.dut_name}.")
+
+            for tacacs_server in tacacs_servers:
+                tacacs_hostname = tacacs_server.get("serverInfo").get("hostname")
+                tops.expected_output["tacacs_servers_info"].update(
+                    {
+                        tacacs_hostname: {
+                            "received_errors": 0,
+                            "connection_disconnects": 0,
+                            "dns_errors": 0,
+                            "send_timeouts": 0,
+                            "connection_timeouts": 0,
+                            "connection_failures": 0,
+                            "received_timeouts": 0,
                         }
-                    )
-                    tops.actual_output["tacacs_servers_info"].update(
-                        {
-                            tacacs_hostname: {
-                                "received_errors": tacacs_server.get("receiveErrors"),
-                                "connection_disconnects": tacacs_server.get(
-                                    "connectionDisconnects"
-                                ),
-                                "dns_errors": tacacs_server.get("dnsErrors"),
-                                "send_timeouts": tacacs_server.get("sendTimeouts"),
-                                "connection_timeouts": tacacs_server.get("connectionTimeouts"),
-                                "connection_failures": tacacs_server.get("connectionFailures"),
-                                "received_timeouts": tacacs_server.get("receiveTimeouts"),
-                            }
+                    }
+                )
+                tops.actual_output["tacacs_servers_info"].update(
+                    {
+                        tacacs_hostname: {
+                            "received_errors": tacacs_server.get("receiveErrors"),
+                            "connection_disconnects": tacacs_server.get(
+                                "connectionDisconnects"
+                            ),
+                            "dns_errors": tacacs_server.get("dnsErrors"),
+                            "send_timeouts": tacacs_server.get("sendTimeouts"),
+                            "connection_timeouts": tacacs_server.get("connectionTimeouts"),
+                            "connection_failures": tacacs_server.get("connectionFailures"),
+                            "received_timeouts": tacacs_server.get("receiveTimeouts"),
                         }
-                    )
+                    }
+                )
 
                 # Forming output message if test result is fail.
                 if tops.expected_output != tops.actual_output:
@@ -113,7 +113,7 @@ class TacacsServersTests:
                                         f" '{actual_value}'."
                                     )
 
-        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+        except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logger.error(
                 "On device %s, Error while running the testcase is:\n%s",

--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -2,23 +2,23 @@
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
-Test cases for verification of TACACS servers details
+Test cases for verification of TACACS server details
 """
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
+from vane import tests_tools, test_case_logger
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
 @pytest.mark.base_services
 class TacacsServersTests:
     """
-    Test cases for verification of TACACS servers details
+    Test cases for verification of TACACS server details
     """
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -40,7 +40,7 @@ class TacacsServersTests:
             "tacacs_servers_info": {}
         }
 
-        # Forming output message if test result is passed
+        # Forming output message if the test result is passed
         tops.output_msg = "TACACS servers have no errors, timeouts, failures or disconnects."
 
         try:
@@ -49,16 +49,13 @@ class TacacsServersTests:
             is correct.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is: \n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is: \n{output}\n"
             )
             self.output += f"Output of {tops.show_cmd} command is: \n{output}"
             tacacs_servers = output.get("tacacsServers")
 
-            # Skipping testcase if TACACS servers are not configured.
+            # Skipping test case if TACACS servers are not configured.
             if not tacacs_servers:
                 pytest.skip(f"TACACS servers are not configured on {tops.dut_name}.")
 
@@ -91,7 +88,7 @@ class TacacsServersTests:
                     }
                 )
 
-                # Forming output message if test result is fail.
+                # Forming output message if the test result fails.
                 if tops.expected_output != tops.actual_output:
                     tops.output_msg = ""
                     for hostname, tacacs_servers_info in tops.expected_output[
@@ -116,8 +113,8 @@ class TacacsServersTests:
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
+            logging.error(
+                "On device %s, Error while running the test case is:\n%s",
                 tops.dut_name,
                 tops.actual_output,
             )

--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2022 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test cases for verification of TACACS servers details
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.base_services
+class TacacsServersTests:
+    """
+    Test cases for verification of TACACS servers details
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_base_services_tacacs"]["duts"]
+    test_ids = dut_parameters["test_base_services_tacacs"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_base_services_tacacs(self, dut, tests_definitions):
+        """
+        TD: Testcase for verification of TACACS servers details.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output, tops.expected_output = {"tacacs_servers_info": {}}, {
+            "tacacs_servers_info": {}
+        }
+
+        # Forming output message if test result is passed
+        tops.output_msg = "TACACS servers have no errors, timeouts, failures or disconnects."
+
+        try:
+            """
+            TS: Running `show tacacs` command on DUT and verifying TACACS servers information
+            is correct.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is: \n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
+            tacacs_servers = output.get('tacacsServers')
+
+            # Skipping testcase if TACACS servers are not configured.
+            if not tacacs_servers:
+                pytest.skip(f"No TACACS servers are configured on {tops.dut_name}.")
+            else:
+                for tacacs_server in tacacs_servers:
+                    tacacs_hostname = tacacs_server.get("serverInfo").get("hostname")
+                    tops.expected_output["tacacs_servers_info"].update(
+                        {
+                            tacacs_hostname: {
+                                "received_errors": 0,
+                                "connection_disconnects": 0,
+                                "dns_errors": 0,
+                                "send_timeouts": 0,
+                                "connection_timeouts": 0,
+                                "connection_failures": 0,
+                                "received_timeouts": 0,
+                            }
+                        }
+                    )
+                    tops.actual_output["tacacs_servers_info"].update(
+                        {
+                            tacacs_hostname: {
+                                "received_errors": tacacs_server.get("receiveErrors"),
+                                "connection_disconnects": tacacs_server.get(
+                                    "connectionDisconnects"
+                                ),
+                                "dns_errors": tacacs_server.get("dnsErrors"),
+                                "send_timeouts": tacacs_server.get("sendTimeouts"),
+                                "connection_timeouts": tacacs_server.get("connectionTimeouts"),
+                                "connection_failures": tacacs_server.get("connectionFailures"),
+                                "received_timeouts": tacacs_server.get("receiveTimeouts"),
+                            }
+                        }
+                    )
+
+                # Forming output message if test result is fail.
+                if tops.expected_output != tops.actual_output:
+                    tops.output_msg = ""
+                    for hostname, tacacs_servers_info in tops.expected_output[
+                        "tacacs_servers_info"
+                    ].items():
+                        actual_servers_info = tops.actual_output.get("tacacs_servers_info").get(
+                            hostname
+                        )
+                        if tacacs_servers_info != actual_servers_info:
+                            tops.output_msg = f"\nFor hostname {hostname}:"
+                            for (error_name, error_value), actual_value in zip(
+                                tacacs_servers_info.items(), actual_servers_info.values()
+                            ):
+                                if error_value != actual_value:
+                                    tops.output_msg += (
+                                        f"\nExpected value of {error_name.replace('_', ' ') } is"
+                                        f" '{error_value}' however actual found as"
+                                        f" '{actual_value}'."
+                                    )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_base_services_tacacs)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -114,9 +114,10 @@ class TacacsServersTests:
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                "On device %s, Error while running the test case is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+                (
+                    f"On device {tops.dut_name}, Error while running the testcase"
+                    f" is:\n{tops.actual_output}"
+                ),
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_base_services_tacacs.py
+++ b/nrfu_tests/test_base_services_tacacs.py
@@ -28,7 +28,8 @@ class TacacsServersTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_base_services_tacacs(self, dut, tests_definitions):
         """
-        TD: Testcase for verification of TACACS servers details.
+        TD: Testcase to verify that TACACS servers have no errors, timeouts, failures or
+        disconnects.
         Args:
             dut(dict): details related to a particular DUT
             tests_definitions(dict): test suite and test case parameters.
@@ -80,9 +81,7 @@ class TacacsServersTests:
                     {
                         tacacs_hostname: {
                             "received_errors": tacacs_server.get("receiveErrors"),
-                            "connection_disconnects": tacacs_server.get(
-                                "connectionDisconnects"
-                            ),
+                            "connection_disconnects": tacacs_server.get("connectionDisconnects"),
                             "dns_errors": tacacs_server.get("dnsErrors"),
                             "send_timeouts": tacacs_server.get("sendTimeouts"),
                             "connection_timeouts": tacacs_server.get("connectionTimeouts"),
@@ -102,15 +101,17 @@ class TacacsServersTests:
                             hostname
                         )
                         if tacacs_servers_info != actual_servers_info:
-                            tops.output_msg = f"\nFor hostname {hostname}:"
+                            tops.output_msg += (
+                                f"\nFor TACACS server {hostname}, following"
+                                " errors/timeouts/disconnects were expected to"
+                                " '0' but in actual found as:\n"
+                            )
                             for (error_name, error_value), actual_value in zip(
                                 tacacs_servers_info.items(), actual_servers_info.values()
                             ):
                                 if error_value != actual_value:
                                     tops.output_msg += (
-                                        f"\nExpected value of {error_name.replace('_', ' ') } is"
-                                        f" '{error_value}' however actual found as"
-                                        f" '{actual_value}'."
+                                        f"{error_name.replace('_', ' ')}:{actual_value}\n"
                                     )
 
         except (AttributeError, LookupError, EapiError) as excep:

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -315,7 +315,7 @@
     show_cmd: show tacacs
     expected_output: null # Forming expected output in test case file.
     test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
-    report_style: modern
+    report_style: modern  # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
     criteria: names
     filter:
     - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -309,13 +309,13 @@
       criteria: names
       filter:
         - BLFE1
-  - name: test_base_services_tacacs
-    description: Testcase for verification of TACACS servers details.
-    test_id: NRFU1.4
-    show_cmd: show tacacs
-    expected_output: null # Forming expected output in test case file.
-    test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
-    report_style: modern  # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
-    criteria: names
-    filter:
-    - BLFE1
+    - name: test_base_services_tacacs
+      description: Testcase for verification of TACACS servers details.
+      test_id: NRFU1.4
+      show_cmd: show tacacs
+      expected_output: null # Forming expected output in the test case file.
+      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
+      report_style: modern  # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      criteria: names
+      filter:
+        - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -315,7 +315,7 @@
     show_cmd: show tacacs
     expected_output: null # Forming expected output in test case file.
     test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
-    report_style: modern ## Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+    report_style: modern
     criteria: names
     filter:
     - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -27,12 +27,13 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_base_services_tacacs
+      description: Testcase for verification of TACACS servers details.
       test_id: NRFU1.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show tacacs
+      expected_output: null # Forming expected output in the test case file.
+      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
+      report_style: modern  # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1
@@ -306,16 +307,6 @@
       show_cmd: null
       expected_output: null
       report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_base_services_tacacs
-      description: Testcase for verification of TACACS servers details.
-      test_id: NRFU1.4
-      show_cmd: show tacacs
-      expected_output: null # Forming expected output in the test case file.
-      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
-      report_style: modern  # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -309,3 +309,13 @@
       criteria: names
       filter:
         - BLFE1
+  - name: test_base_services_tacacs
+    description: Testcase for verification of TACACS servers details.
+    test_id: NRFU1.4
+    show_cmd: show tacacs
+    expected_output: null # Forming expected output in test case file.
+    test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass/fail criteria for reporting.
+    report_style: modern ## Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+    criteria: names
+    filter:
+    - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -282,5 +282,5 @@
       expected_output: null #Forming expected output in test case file.
       test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass / fail criteria for reporting
       report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
-      criteria: {{ global_dut_filter["criteria"] }}
-      filter: {{ global_dut_filter["filter"] }}
+      criteria: {{ global_dut_filter.criteria }}
+      filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -275,3 +275,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
+    - name: test_base_services_tacacs
+      description: Testcase for verification of TACACS servers details.
+      test_id: NRFU1.4
+      show_cmd: show tacacs
+      expected_output: null #Forming expected output in test case file.
+      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass / fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      criteria: {{ global_dut_filter["criteria"] }}
+      filter: {{ global_dut_filter["filter"] }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -279,11 +279,11 @@
       description: Testcase for verification of TACACS servers details.
       test_id: NRFU1.4
       show_cmd: show tacacs
-      # Forming expected output in test case file.
+      # Forming expected output in the test case file.
       expected_output: null
       # Setting test case’s pass/fail criteria for reporting.
       test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects.
-      # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -279,8 +279,11 @@
       description: Testcase for verification of TACACS servers details.
       test_id: NRFU1.4
       show_cmd: show tacacs
-      expected_output: null #Forming expected output in test case file.
-      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects. # Setting test case’s pass / fail criteria for reporting
-      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      # Forming expected output in test case file.
+      expected_output: null
+      # Setting test case’s pass/fail criteria for reporting.
+      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects.
+      # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -24,11 +24,15 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_base_services_tacacs
+      description: Testcase for verification of TACACS servers details.
       test_id: NRFU1.4
-      show_cmd: null
+      show_cmd: show tacacs
+      # Forming expected output in the test case file.
       expected_output: null
+      # Setting test case’s pass/fail criteria for reporting.
+      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects.
+      # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
@@ -272,18 +276,6 @@
       test_id: NRFU6.11
       show_cmd: null
       expected_output: null
-      report_style: modern
-      criteria: {{ global_dut_filter.criteria }}
-      filter: {{ global_dut_filter.filter }}
-    - name: test_base_services_tacacs
-      description: Testcase for verification of TACACS servers details.
-      test_id: NRFU1.4
-      show_cmd: show tacacs
-      # Forming expected output in the test case file.
-      expected_output: null
-      # Setting test case’s pass/fail criteria for reporting.
-      test_criteria: TACACS servers should not have errors, timeouts, failures or disconnects.
-      # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_base_services_tacacs.py as per the vane style guide along with that updated following files.
test_definition.yaml: Updated test def with testcase NRFU1.4
test_definition.yaml.j2 and master_def.yaml : Updated J2 with testcase NRFU1.4

# Any specific logic/part of code you need extra attention on

Verified TACACS servers have no errors, timeouts, failures or disconnects and test case should failed when No TACACS servers are configured on the device.

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/422


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (nrfu_tests)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?
**Note: Tested with using hardcoded output**
Unit tests and report :

1) Pass_case : Tested that TACACS servers have no errors, timeouts, failures or disconnects.
Reports:

[pass_with_j2.docx](https://github.com/aristanetworks/vane/files/12599311/pass_with_j2.docx)

[pass_report.docx](https://github.com/aristanetworks/vane/files/12610130/pass_report.docx)

2) Fail_case : Tested that test case should failed when all TACACS servers details are incorrect 
Reports:


[all_fail.docx](https://github.com/aristanetworks/vane/files/12609686/all_fail.docx)

3) Fail_case : Tested that test case should failed when one or more the TACACS servers details are incorrect 
Reports:

[fail_with_two_servers.docx](https://github.com/aristanetworks/vane/files/12497831/fail_with_two_servers.docx)

4) Fail_case : Tested that test case should failed when No TACACS servers are configured on the device.

[No_TACACS_servers_are_configured.docx](https://github.com/aristanetworks/vane/files/12497834/No_TACACS_servers_are_configured.docx)

HTML reports for all mentioned unit testcases:

[test_base_services_tacacs.zip](https://github.com/aristanetworks/vane/files/12610134/test_base_services_tacacs.zip)


## Bug fix



    
## New feature
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    
# Additional comments
