### PR TITLE
issue-442: Convert Pytest-CVP Core Dump test case to Vane

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -228,12 +228,14 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_hardware_core_dump_files
+      description: Test case for verification of core dump files
       test_id: NRFU6.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show system coredump
+      expected_output:
+        core_dump_files_not_found: True
+      test_criteria: Core dump files should not found on the device. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -1,313 +1,314 @@
 - name: nrfu_tests
   testcases:
-    - name: test_
-      description: null
-      test_id: NRFU1.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU1.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU1.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU1.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.5
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU2.6
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU3.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU4.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU4.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU4.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU4.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.5
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_security_rp_ssh_access_list
-      description: Test case to verify that ACL is configured for each VRF on which SSH is enabled
-      test_id: NRFU5.6
-      show_cmds:
-        - show vrf
-        - show management ssh ip access-list summary
-      expected_output: null # Expected output is formed inside a test case file dynamically.
-      test_criteria: All VRFs that the API is active on should have an ACL to be configured.
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.7
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU5.8
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_hardware_core_dump_files
-      description: Test case for verification of core dump files
-      test_id: NRFU6.3
-      show_cmd: show system coredump
-      expected_output:
-        core_dump_files_not_found: True
-      test_criteria: Core dump files should not found on the device. # Setting test case’s pass/fail criteria for reporting
-      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.5
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.6
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.7
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.8
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.9
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.10
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
-    - name: test_
-      description: null
-      test_id: NRFU6.11
-      show_cmd: null
-      expected_output: null
-      report_style: modern
-      criteria: names
-      filter:
-        - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU1.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU1.2
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU1.3
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU1.4
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.2
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.3
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.4
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.5
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU2.6
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU3.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU4.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU4.2
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU4.3
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU4.4
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.2
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.3
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.4
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.5
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_security_rp_ssh_access_list
+    description: Test case to verify that ACL is configured for each VRF on which
+      SSH is enabled
+    test_id: NRFU5.6
+    show_cmds:
+    - show vrf
+    - show management ssh ip access-list summary
+    expected_output: null
+    test_criteria: All VRFs that the API is active on should have an ACL to be configured.
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.7
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU5.8
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.1
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.2
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_hardware_core_dump_files
+    description: Test case for verification of core dump files
+    test_id: NRFU6.3
+    show_cmd: show system coredump
+    expected_output:
+      core_dump_files_not_found: true
+    test_criteria: Core dump files should not be found on the device.
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.4
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.5
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.6
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.7
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.8
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.9
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.10
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1
+  - name: test_
+    description: null
+    test_id: NRFU6.11
+    show_cmd: null
+    expected_output: null
+    report_style: modern
+    criteria: names
+    filter:
+    - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -1,314 +1,313 @@
 - name: nrfu_tests
   testcases:
-  - name: test_
-    description: null
-    test_id: NRFU1.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU1.2
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU1.3
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU1.4
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.2
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.3
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.4
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.5
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU2.6
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU3.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU4.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU4.2
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU4.3
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU4.4
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.2
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.3
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.4
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.5
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_security_rp_ssh_access_list
-    description: Test case to verify that ACL is configured for each VRF on which
-      SSH is enabled
-    test_id: NRFU5.6
-    show_cmds:
-    - show vrf
-    - show management ssh ip access-list summary
-    expected_output: null
-    test_criteria: All VRFs that the API is active on should have an ACL to be configured.
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.7
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU5.8
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.1
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.2
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_hardware_core_dump_files
-    description: Test case for verification of core dump files
-    test_id: NRFU6.3
-    show_cmd: show system coredump
-    expected_output:
-      core_dump_files_not_found: true
-    test_criteria: Core dump files should not be found on the device.
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.4
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.5
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.6
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.7
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.8
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.9
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.10
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
-  - name: test_
-    description: null
-    test_id: NRFU6.11
-    show_cmd: null
-    expected_output: null
-    report_style: modern
-    criteria: names
-    filter:
-    - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU1.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU1.2
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU1.3
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU1.4
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.2
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.3
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.4
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.5
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU2.6
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU3.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU4.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU4.2
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU4.3
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU4.4
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.2
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.3
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.4
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.5
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_security_rp_ssh_access_list
+      description: Test case to verify that ACL is configured for each VRF on which SSH is enabled
+      test_id: NRFU5.6
+      show_cmds:
+        - show vrf
+        - show management ssh ip access-list summary
+      expected_output: null # Expected output is formed inside a test case file dynamically.
+      test_criteria: All VRFs that the API is active on should have an ACL to be configured.
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.7
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU5.8
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.1
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.2
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_hardware_core_dump_files
+      description: Test case for verification of core dump files
+      test_id: NRFU6.3
+      show_cmd: show system coredump
+      expected_output:
+        core_dump_files_not_found: True
+      test_criteria: Core dump files should not be found on the device. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.4
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.5
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.6
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.7
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.8
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.9
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.10
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1
+    - name: test_
+      description: null
+      test_id: NRFU6.11
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      criteria: names
+      filter:
+        - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -203,11 +203,13 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_hardware_core_dump_files
+      description: Test case for verification of core dump files
       test_id: NRFU6.3
-      show_cmd: null
-      expected_output: null
+      show_cmd: show system coredump
+      expected_output:
+        core_dump_files_not_found: True
+      test_criteria: Core dump files should not found on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -209,7 +209,7 @@
       show_cmd: show system coredump
       expected_output:
         core_dump_files_not_found: True
-      test_criteria: Core dump files should not found on the device.
+      test_criteria: Core dump files should not be found on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_system_hardware_coredump.py
+++ b/nrfu_tests/test_system_hardware_coredump.py
@@ -7,11 +7,11 @@ Test case for verification of core dump files
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
+from vane import tests_tools, test_case_logger
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -42,29 +42,25 @@ class CoreDumpFilesTests:
         try:
             """
             TS: Running `show system coredump` command on dut and verifying that core dump files
-            should not found on the device.
+            should not be found on the device.
             """
             core_dump = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                core_dump,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{core_dump}\n"
             )
             self.output = f"Output of {tops.show_cmd} command is:\n{core_dump}"
             core_dump = core_dump["coreFiles"]
             tops.actual_output["core_dump_files_not_found"] = not bool(core_dump)
 
-            # Output message formation in case of testcase fails.
+            # Output message formation in case test case fails.
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = "Core dump files are found on the device."
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}, Error while running the test case"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_system_hardware_coredump.py
+++ b/nrfu_tests/test_system_hardware_coredump.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test case for verification of core dump files
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.system
+class CoreDumpFilesTests:
+    """
+    Test case for verification of core dump files
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_hardware_core_dump_files"]["duts"]
+    test_ids = dut_parameters["test_hardware_core_dump_files"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_hardware_core_dump_files(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of core dump files
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {}
+        tops.output_msg = "Core dump files are not found on the device."
+
+        try:
+            """
+            TS: Running `show system coredump` command on dut and verifying that core dump files
+            should not found on the device.
+            """
+            core_dump = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                core_dump,
+            )
+            self.output = f"Output of {tops.show_cmd} command is:\n{core_dump}"
+            core_dump = core_dump["coreFiles"]
+            tops.actual_output["core_dump_files_not_found"] = not bool(core_dump)
+
+            # Output message formation in case of testcase fails.
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = "Core dump files are found on the device."
+
+        except (AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_hardware_core_dump_files)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes

* test_definition.yaml
Updated test def with testcase NRFU6.3.
* test_definition.yaml.j2 
Updated J2 with testcase NRFU6.3.
* master_def.yaml
Updated master def with testcase NRFU6.3.
* test_system_hardware_coredump.py
Added python file for testcase NRFU6.3.

# Any specific logic/part of code you need extra attention on

Testcase check if core dump files found then fail it.

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/442

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (Convert Pytest-CVP Core Dump test case to Vane)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
1. Testcase pass when no core dump files are found.
Reports with J2: [report_2308311539_j2_pass.docx](https://github.com/aristanetworks/vane/files/12485111/report_2308311539_j2_pass.docx)
Reports with test def:[report_2308311547_pass.docx](https://github.com/aristanetworks/vane/files/12485115/report_2308311547_pass.docx)

2. Testcase failed when core dump files are found.
Reports: [report_2308311552_fail.docx](https://github.com/aristanetworks/vane/files/12485122/report_2308311552_fail.docx)

HTML reports: [html reports.zip](https://github.com/aristanetworks/vane/files/12485127/html.reports.zip)

Updated pass html report after logger change: [report_2309141723.zip](https://github.com/aristanetworks/vane/files/12608411/report_2309141723.zip)

