### PR TITLE
Issue_428: Convert Pytest-CVP Port-Channel test case to Vane #428

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -82,7 +82,7 @@
       filter:
         - BLFE1
     - name: test_port_channel_member_interface_details
-      description: Testcases for the verification of port channel member interfaces should be collecting and distributing.
+      description: Testcases to verify that port channel member interfaces should be collecting and distributing.
       test_id: NRFU2.6
       show_cmd: show lacp interface all-ports
       expected_output: null # Forming expected output dynamically inside the testcase.

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -81,12 +81,13 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_port_channel_member_interface_details
+      description: Testcases for the verification of port channel member interfaces should be collecting and distributing.
       test_id: NRFU2.6
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show lacp interface all-ports
+      expected_output: null # Forming expected output dynamically inside the testcase.
+      test_criteria: All the port channel members interfaces should be collecting and distributing. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern, If a report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -72,8 +72,8 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-      - name: test_port_channel_member_interface_details
-      description: Testcases for the verification of port channel member interfaces should be collecting and distributing.
+    - name: test_port_channel_member_interface_details
+      description: Testcases to verify that port channel member interfaces should be collecting and distributing.
       test_id: NRFU2.6
       show_cmd: show lacp interface all-ports
       expected_output: null

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -72,11 +72,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+      - name: test_port_channel_member_interface_details
+      description: Testcases for the verification of port channel member interfaces should be collecting and distributing.
       test_id: NRFU2.6
-      show_cmd: null
+      show_cmd: show lacp interface all-ports
       expected_output: null
+      test_criteria: All the port channel members interfaces should be collecting and distributing.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_interfaces_port_channels.py
+++ b/nrfu_tests/test_interfaces_port_channels.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+""" Testcases for the verification of port channel members interfaces details """
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.interfaces
+class PortChannelMemberInterfacesTests:
+    """Testcases for the verification of port channel members interfaces details"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_port_channel_member_interface_details"]["duts"]
+    test_ids = dut_parameters["test_port_channel_member_interface_details"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_port_channel_member_interface_details(self, dut, tests_definitions):
+        """
+        TD: Testcases for the verification of port channel members interfaces should
+        be collecting and distributing.
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {"port_channels": {}}
+        tops.expected_output = {"port_channels": {}}
+        # Forming output message if test result is pass
+        tops.output_msg = "All the port channel members interfaces are collecting and distributing."
+
+        try:
+            """
+            TS: Running `show lacp interface all-ports` on DUT and verifying that the
+            port channel members interfaces are collecting and distributing.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output = f"\nOutput of {tops.show_cmd} command is: \n{output}"
+
+            # Skipping testcase if port channel details are not found on DUT.
+            if not output.get("portChannels"):
+                pytest.skip("Port-Channels are not found hence skipped the testcase.")
+
+            expected_partner_port_state = {
+                "partner_port_state": {"collecting": True, "distributing": True}
+            }
+
+            for port_channel in output.get("portChannels"):
+                tops.expected_output["port_channels"].update({port_channel: {"interfaces": {}}})
+                tops.actual_output["port_channels"].update({port_channel: {"interfaces": {}}})
+                interface_data = output["portChannels"][port_channel].get("interfaces")
+
+                for interface in interface_data:
+                    tops.expected_output["port_channels"][port_channel]["interfaces"].update(
+                        {interface: expected_partner_port_state}
+                    )
+                    partner_port_state = interface_data[interface].get("partnerPortState", {})
+                    interface_partner_port_state = {
+                        "partner_port_state": {
+                            "collecting": partner_port_state.get("collecting"),
+                            "distributing": partner_port_state.get("distributing"),
+                        }
+                    }
+                    tops.actual_output["port_channels"][port_channel]["interfaces"].update(
+                        {interface: interface_partner_port_state}
+                    )
+
+            # Forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = "\n"
+
+                # Iterating over port channels details.
+                for port_channel, port_channel_data in tops.actual_output["port_channels"].items():
+                    not_collecting_interfaces = []
+                    not_distributing_interfaces = []
+                    output = ""
+
+                    for interface, interface_data in port_channel_data["interfaces"].items():
+                        collecting_state = interface_data["partner_port_state"]["collecting"]
+                        distributing_state = interface_data["partner_port_state"]["distributing"]
+
+                        if not collecting_state:
+                            not_collecting_interfaces.append(interface)
+
+                        if not distributing_state:
+                            not_distributing_interfaces.append(interface)
+
+                    if not_collecting_interfaces:
+                        output = (
+                            "Following members interfaces are not having the collecting state:"
+                            f" {', '.join(not_collecting_interfaces)}.\n"
+                        )
+
+                    if not_distributing_interfaces:
+                        output += (
+                            "Following members interfaces are not having the distributing state:"
+                            f" {', '.join(not_distributing_interfaces)}.\n"
+                        )
+
+                    if output:
+                        tops.output_msg += f"For {port_channel}:\n{output}\n"
+
+        except (AttributeError, LookupError, EapiError) as excp:
+            tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error occurred while running testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_port_channel_member_interface_details)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_interfaces_port_channels.py
+++ b/nrfu_tests/test_interfaces_port_channels.py
@@ -5,11 +5,11 @@
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane import tests_tools
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -24,7 +24,7 @@ class PortChannelMemberInterfacesTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_port_channel_member_interface_details(self, dut, tests_definitions):
         """
-        TD: Testcases for the verification of port channel members interfaces should
+        TD: Testcases to verify that port channel members interfaces should
         be collecting and distributing.
         Args:
           dut(dict): Details related to the switches
@@ -43,11 +43,8 @@ class PortChannelMemberInterfacesTests:
             port channel members interfaces are collecting and distributing.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n",
             )
             self.output = f"\nOutput of {tops.show_cmd} command is: \n{output}"
 
@@ -116,10 +113,9 @@ class PortChannelMemberInterfacesTests:
 
         except (AttributeError, LookupError, EapiError) as excp:
             tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s: Error occurred while running testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}: Error occurred while running testcase"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_interfaces_port_channels.py as per the vane style guide along with the updated following files.
test_definition.yaml: Updated test def with testcase NRFU2.6
test_definition.yaml.j2: Updated J2 with testcase NRFU2.6
nrfu_tests/test_interfaces_port_channels.py:  Added converted testsuite file for testcases NRFU2.6

# Any specific logic/part of code you need extra attention on
   From the output of  **show lacp interface all-ports**,  verified that the all port-channel interface members are collecting and distributing , if port channels are not found then testcase will skip.

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/428

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU testcases)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?
Unit testcases:
 - Tested the same testcase with all portchannel interface members collecting and distributing: Passed (after adding the latest logger)
    Report: 
   [report_pass_port_channel.docx](https://github.com/aristanetworks/vane/files/12586198/report_pass_port_channel.docx)


- Tested with portchannel details are not found on the device: Skipped (tested withHardcoded output)
  Reports:
  [report_po_skipped.docx](https://github.com/aristanetworks/vane/files/12521255/report_po_skipped.docx)

- Tested with a few portchannel interface members are not collecting and distributing: Failed
  Reports:
  [report_po_failed_.docx](https://github.com/aristanetworks/vane/files/12522419/report_po_failed_.docx)

- Reports with j2 
  [report_po_pass.docx](https://github.com/aristanetworks/vane/files/12521248/report_po_pass.docx)


HTML reports:
[ps_po.zip](https://github.com/aristanetworks/vane/files/12586191/ps_po.zip)




## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
