### PR TITLE
Issue_424 Added TC for NRFU2.2 interface status error disabled status

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -50,7 +50,7 @@
       test_id: NRFU2.2
       show_cmd: show interfaces status errdisabled
       expected_output: null  # Forming the expected output dictionary in test file
-      test_criteria: No interface should be in error disabled state. # Setting test case’s pass/fail criteria for reporting
+      test_criteria: None of the interface should be in error disabled state. # Setting test case’s pass/fail criteria for reporting
       report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -45,12 +45,13 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_interfaces_errdisabled_status
+      description: Test case for verification of interface errdisabled status.
       test_id: NRFU2.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show interfaces status errdisabled
+      expected_output: null  # Forming the expected output dictionary in test file
+      test_criteria: No interface should be in error disabled state. . # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -54,7 +54,7 @@
       report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
-        - BLFE1
+        - BLFE1  # Device on which tests run
     - name: test_
       description: null
       test_id: NRFU2.3

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -50,7 +50,7 @@
       test_id: NRFU2.2
       show_cmd: show interfaces status errdisabled
       expected_output: null  # Forming the expected output dictionary in test file
-      test_criteria: No interface should be in error disabled state. . # Setting test case’s pass/fail criteria for reporting
+      test_criteria: No interface should be in error disabled state. # Setting test case’s pass/fail criteria for reporting
       report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -45,7 +45,7 @@
       test_id: NRFU2.2
       show_cmd: show interfaces status errdisabled
       expected_output: null
-      test_criteria: No interface should be in error disabled state.
+      test_criteria: None of the interface should be in error disabled state.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -40,11 +40,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_interfaces_errdisabled_status
+      description: Test case for verification of interface errdisabled status.
       test_id: NRFU2.2
-      show_cmd: null
+      show_cmd: show interfaces status errdisabled
       expected_output: null
+      test_criteria: No interface should be in error disabled state.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
 # Arista Networks, Inc. Confidential and Proprietary.
 
-"""Testcases for verification of Interface status functionality"""
+"""Testcases for verification of interface  status functionality"""
 
 import pytest
 from pyeapi.eapilib import EapiError
@@ -16,7 +16,7 @@ TEST_SUITE = "nrfu_tests"
 @pytest.mark.interfaces
 class InterfaceStatusTests:
 
-    """Testcases for verification of Interface status functionality"""
+    """Testcases for verification of interface  status functionality"""
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
     test_duts = dut_parameters["test_interfaces_errdisabled_status"]["duts"]
@@ -37,12 +37,12 @@ class InterfaceStatusTests:
         tops.actual_output = {"interface_state_details": {}}
 
         # Forming output message if test result is pass
-        tops.output_msg = "No interface is in error disabled state."
+        tops.output_msg = "None of the interface is in error disabled state."
 
         try:
             """
-            TS: Running `show interfaces status errdisabled` command and verifying the
-            no interface is in error disabled state.
+            TS: Running `show interfaces status errdisabled` command and verifying that the
+            none of the interface is in error disabled state.
             """
             interface_details = dut["output"][tops.show_cmd]["json"]
             logger.info(
@@ -73,7 +73,7 @@ class InterfaceStatusTests:
                         f"\n{interface}:\nDescription: {description} and cause: {causes}."
                     )
 
-        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+        except (AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
             logger.error(
                 "On device %s: Error while running the testcase is:\n%s",

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -70,7 +70,7 @@ class InterfaceStatusTests:
                     )
                     description = interface_statuses.get(interface, {}).get("description")
                     tops.output_msg += (
-                        f"\n{interface},\nDescription: {description} and Causes: {causes}"
+                        f"\n{interface}:\nDescription: {description} and cause: {causes}."
                     )
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -5,11 +5,11 @@
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane import tests_tools
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -45,11 +45,8 @@ class InterfaceStatusTests:
             none of the interface is in error disabled state.
             """
             interface_details = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, Output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                interface_details,
+            logging.info(
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} command is:\n{interface_details}\n"
             )
             interface_statuses = interface_details.get("interfaceStatuses")
             tops.expected_output["interface_state_details"] = {
@@ -72,10 +69,8 @@ class InterfaceStatusTests:
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s: Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}: Error while running the testcase is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""Testcases for verification of Interface status functionality"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.interfaces
+class InterfaceStatusTests:
+
+    """Testcases for verification of Interface status functionality"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_interfaces_errdisabled_status"]["duts"]
+    test_ids = dut_parameters["test_interfaces_errdisabled_status"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_interfaces_errdisabled_status(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of interface errdisabled status
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.expected_output = {"interface_state_details": {}}
+        tops.actual_output = {"interface_state_details": {}}
+
+        # Forming output message if test result is pass
+        tops.output_msg = "No interface is in error disabled state."
+
+        try:
+            """
+            TS: Running `show interfaces status errdisabled` command and verifying the
+            no interface is in error disabled state.
+            """
+            interface_details = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, Output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                interface_details,
+            )
+            interface_statuses = interface_details.get("interfaceStatuses")
+            tops.expected_output["interface_state_details"] = {
+                "no_interface_in_error_disabled_state": True
+            }
+            tops.actual_output["interface_state_details"] = {
+                "no_interface_in_error_disabled_state": not bool(interface_statuses)
+            }
+
+            # forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = "\nFollowing interfaces are in errdisabled state:"
+                for interface in interface_statuses:
+                    causes = (
+                        str(interface_statuses.get(interface, {}).get("causes"))
+                        .lstrip("[")
+                        .rstrip("]")
+                    )
+                    description = interface_statuses.get(interface, {}).get("description")
+                    tops.output_msg += (
+                        f"\n{interface},\nDescription: {description} and Causes: {causes}"
+                    )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_interfaces_errdisabled_status)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -46,7 +46,8 @@ class InterfaceStatusTests:
             """
             interface_details = dut["output"][tops.show_cmd]["json"]
             logging.info(
-                f"On device {tops.dut_name}, Output of {tops.show_cmd} command is:\n{interface_details}\n"
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} command"
+                f" is:\n{interface_details}\n"
             )
             interface_statuses = interface_details.get("interfaceStatuses")
             tops.expected_output["interface_state_details"] = {
@@ -70,7 +71,8 @@ class InterfaceStatusTests:
         except (AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                f"On device {tops.dut_name}: Error while running the testcase is:\n{tops.actual_output}"
+                f"On device {tops.dut_name}: Error while running the testcase"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_interfaces_errdisabled.py
+++ b/nrfu_tests/test_interfaces_errdisabled.py
@@ -61,17 +61,14 @@ class InterfaceStatusTests:
 
             # forming output message if test result is fail
             if tops.actual_output != tops.expected_output:
-                tops.output_msg = "\nFollowing interfaces are in errdisabled state:"
+                tops.output_msg = "\nFollowing interfaces are in errdisabled state with causes:"
                 for interface in interface_statuses:
                     causes = (
                         str(interface_statuses.get(interface, {}).get("causes"))
                         .lstrip("[")
                         .rstrip("]")
                     )
-                    description = interface_statuses.get(interface, {}).get("description")
-                    tops.output_msg += (
-                        f"\n{interface}:\nDescription: {description} and cause: {causes}."
-                    )
+                    tops.output_msg += f"\n{interface}: {causes}."
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]


### PR DESCRIPTION
# Please include a summary of the changes

test_definition.yaml: Updated test def with testcase NRFU2.2
test_definition.yaml.j2: Updated J2 with testcase NRFU2.2
test_interfaces_errdisabled.py: Added python file for testcase NRFU2.2

# Any specific logic/part of code you need extra attention on

Running `show interfaces status errdisabled` command and verifying the no interface is in error disabled state.

# Issue_ID: https://github.com/aristanetworks/vane/issues/424


# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU Tests)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

   
# Reports

Passed report when none of the interface is in error disabled state.
[report_passed.docx](https://github.com/aristanetworks/vane/files/12607063/report_passed.docx)



Passed report with j2
[report_passed_j2.docx](https://github.com/aristanetworks/vane/files/12607057/report_passed_j2.docx)




Failed report when test criteria does not met.
[report_failed.docx](https://github.com/aristanetworks/vane/files/12607055/report_failed.docx)



Html reports
[html_report.zip](https://github.com/aristanetworks/vane/files/12607050/html_report.zip)






