### PR TITLE
Added TC for NRFU4.4 Multi agent routing protocol functionality

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -155,7 +155,7 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_routing_multi_agent
+    - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4
       show_cmd: show ip route summary

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -163,7 +163,7 @@
         multi_agent_routing_protocol:
           configured: true
           operational: true
-      test_criteria: Multi Agent Routing Model protocol should be configured and operational on the device.   # Setting test case’s pass/fail criteria for reporting
+      test_criteria: Multi agent routing model protocol should be configured and operational on the device.   # Setting test case’s pass/fail criteria for reporting
       report_style: modern  # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -155,12 +155,16 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_routing_multi_agent
+      description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show ip route summary
+      expected_output:
+        multi_agent_routing_protocol:
+          configured: true
+          operational: true
+      test_criteria: Multi Agent Routing Model protocol should be configured and operational on the device.   # Setting test case’s pass/fail criteria for reporting
+      report_style: modern  # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -167,7 +167,7 @@
       report_style: modern  # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
-        - BLFE1
+        - BLFE1  # Device on which tests run
     - name: test_acls_api_vrfs_enabled
       description: Test case to verify that ACL is configured for each VRF on which API is enabled.
       test_id: NRFU5.1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -145,7 +145,7 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_routing_multi_agent
+    - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4
       show_cmd: show ip route summary

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -153,7 +153,7 @@
         multi_agent_routing_protocol:
           configured: True
           operational: True
-      test_criteria: Multi Agent Routing Model protocol should be configured and operational on the device.
+      test_criteria: Multi agent routing model protocol should be configured and operational on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -145,11 +145,15 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_routing_multi_agent
+      description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4
-      show_cmd: null
-      expected_output: null
+      show_cmd: show ip route summary
+      expected_output:
+        multi_agent_routing_protocol:
+          configured: True
+          operational: True
+      test_criteria: Multi Agent Routing Model protocol should be configured and operational on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -5,11 +5,11 @@
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane import tests_tools
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -48,11 +48,9 @@ class MultiAgentRoutingProtocolTests:
             protocol is configured and operational on the device.
             """
             route_summary = dut["output"][tops.show_cmd]["text"]
-            logger.info(
-                "On device %s, Output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                route_summary,
+            logging.info(
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} command"
+                f" is:\n{route_summary}\n"
             )
             self.output += (
                 f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{route_summary}\n"
@@ -86,10 +84,9 @@ class MultiAgentRoutingProtocolTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s: Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}: Error while running the testcase"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -71,16 +71,16 @@ class MultiAgentRoutingProtocolTests:
 
             # forming output message if test result is fail
             if tops.actual_output != tops.expected_output:
-                tops.output_msg = f"\nOn device {tops.dut_name}:\n"
+                tops.output_msg = "\n"
                 if not tops.actual_output["multi_agent_routing_protocol"]["operational"]:
                     if tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (
-                            "Multi agent routing protocol is configured but not is in operational"
-                            " state."
+                            "Multi agent routing protocol is configured but it is not in the"
+                            " operational"
                         )
                     if not tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (
-                            "Multi agent routing protocol is neither configured nor is in"
+                            "Multi agent routing protocol is neither configured nor in"
                             " operational state."
                         )
 

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -39,13 +39,13 @@ class MultiAgentRoutingProtocolTests:
 
         # Forming output message if test result is pass
         tops.output_msg = (
-            "Multi Agent Routing Model protocol is configured and operational on the device."
+            "Multi agent routing model protocol is configured and operational on the device."
         )
 
         try:
             """
-            TS: Running 'show ip route summary' command and Verifying Multi Agent Routing Model
-            is enabled.
+            TS: Running 'show ip route summary' command and verifying multi agent routing model
+            protocol is configured and operational on the device.
             """
             route_summary = dut["output"][tops.show_cmd]["text"]
             logger.info(
@@ -75,12 +75,12 @@ class MultiAgentRoutingProtocolTests:
                 if not tops.actual_output["multi_agent_routing_protocol"]["operational"]:
                     if tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (
-                            "Multi Agent routing protocol is configured but not is in operational"
+                            "Multi agent routing protocol is configured but not is in operational"
                             " state."
                         )
                     if not tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (
-                            "Multi Agent routing protocol is neither configured nor is in"
+                            "Multi agent routing protocol is neither configured nor is in"
                             " operational state."
                         )
 

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -19,15 +19,15 @@ class MultiAgentRoutingProtocolTests:
     """Testcases for verification of multi-agent routing functionality"""
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
-    test_duts = dut_parameters["test_routing_multi_agent"]["duts"]
-    test_ids = dut_parameters["test_routing_multi_agent"]["ids"]
+    test_duts = dut_parameters["test_multi_agent_routing_protocol"]["duts"]
+    test_ids = dut_parameters["test_multi_agent_routing_protocol"]["ids"]
 
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
-    def test_routing_multi_agent(self, dut, tests_definitions):
+    def test_multi_agent_routing_protocol(self, dut, tests_definitions):
         """
         TD: Test case for verification of multi-agent routing model functionality
         Args:
-          dut(dict): Details related to the switches
+          dut(dict): Details related to particular DUT
           tests_definitions(dict): Test suite and test case parameters
         """
 
@@ -93,6 +93,6 @@ class MultiAgentRoutingProtocolTests:
             )
 
         tops.test_result = tops.expected_output == tops.actual_output
-        tops.parse_test_steps(self.test_routing_multi_agent)
+        tops.parse_test_steps(self.test_multi_agent_routing_protocol)
         tops.generate_report(tops.dut_name, self.output)
         assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""Testcases for verification of multi-agent routing functionality"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.routing
+class MultiAgentRoutingProtocolTests:
+
+    """Testcases for verification of multi-agent routing functionality"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_routing_multi_agent"]["duts"]
+    test_ids = dut_parameters["test_routing_multi_agent"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_routing_multi_agent(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of multi-agent routing model functionality
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {"multi_agent_routing_protocol": {}}
+        operating_model = "Operating routing protocol model: multi-agent"
+        configured_model = "Configured routing protocol model: multi-agent"
+
+        # Forming output message if test result is pass
+        tops.output_msg = (
+            "Multi Agent Routing Model protocol is configured and operational on the device."
+        )
+
+        try:
+            """
+            TS: Running 'show ip route summary' command and Verifying Multi Agent Routing Model
+            is enabled.
+            """
+            route_summary = dut["output"][tops.show_cmd]["text"]
+            logger.info(
+                "On device %s, Output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                route_summary,
+            )
+            self.output += (
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{route_summary}\n"
+            )
+            assert route_summary, "Routing model details are not found."
+
+            # Verify multi-agent is configured
+            tops.actual_output["multi_agent_routing_protocol"]["configured"] = (
+                configured_model in route_summary
+            )
+
+            # Verify multi-agent is configured
+            tops.actual_output["multi_agent_routing_protocol"]["operational"] = (
+                operating_model in route_summary
+            )
+
+            # forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = f"\nOn device {tops.dut_name}:\n"
+                if not tops.actual_output["multi_agent_routing_protocol"]["operational"]:
+                    if tops.actual_output["multi_agent_routing_protocol"]["configured"]:
+                        tops.output_msg += (
+                            "Multi Agent routing protocol is configured but not is in operational"
+                            " state."
+                        )
+                    if not tops.actual_output["multi_agent_routing_protocol"]["configured"]:
+                        tops.output_msg += (
+                            "Multi Agent routing protocol is neither configured nor is in"
+                            " operational state."
+                        )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_routing_multi_agent)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_routing_multi_agent.py
+++ b/nrfu_tests/test_routing_multi_agent.py
@@ -71,12 +71,12 @@ class MultiAgentRoutingProtocolTests:
 
             # forming output message if test result is fail
             if tops.actual_output != tops.expected_output:
-                tops.output_msg = "\n"
+                tops.output_msg = ""
                 if not tops.actual_output["multi_agent_routing_protocol"]["operational"]:
                     if tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (
                             "Multi agent routing protocol is configured but it is not in the"
-                            " operational"
+                            " operational state."
                         )
                     if not tops.actual_output["multi_agent_routing_protocol"]["configured"]:
                         tops.output_msg += (


### PR DESCRIPTION
# Please include a summary of the changes

test_definition.yaml: Updated test def with testcase NRFU4.4
test_definition.yaml.j2: Updated J2 with testcase NRFU4.4
test_routing_multi_agent.py: Added python file for testcase NRFU4.4

# Any specific logic/part of code you need extra attention on

Running 'show ip route summary' command and verifying multi agent routing model protocol is configured and operational on the device

# Issue_ID: https://github.com/aristanetworks/vane/issues/433


# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU Tests)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# Reports

Passed reports when multi agent enabled on device
[report_passed.docx](https://github.com/aristanetworks/vane/files/12483586/report_passed.docx)

Passed report using j2
[report_passed_j2.docx](https://github.com/aristanetworks/vane/files/12495441/report_passed_j2.docx)




Failed report when multi agent routing model protocol is not enabled(ribd mode enabled)
[report_failed.docx](https://github.com/aristanetworks/vane/files/12495458/report_failed.docx)





Failed reports when multi agent routing protocol is configured but not in operational state (tested using hardcode output)
[report_failed_not_operational_state.docx](https://github.com/aristanetworks/vane/files/12485747/report_failed_not_operational_state.docx)



Failed reports when routing details not found.(tested using hardcode output)
[report_assert_failed.docx](https://github.com/aristanetworks/vane/files/12485745/report_assert_failed.docx)


Html Reports
[html_reports.zip](https://github.com/aristanetworks/vane/files/12485743/html_reports.zip)




