### PR TITLE
Added TC for NRFU5.3 LLDP neighbor functionality testcase

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -153,12 +153,13 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_eos_no_config_functionality
+      description: Testcases for verification of security root port EOS no configurations functionality.
       test_id: NRFU5.3
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show lldp neighbors detail
+      expected_output: null   # Forming expected output dictionary in testcase file
+      test_criteria: No localhost should found in LLDP information on device.   # Setting test case’s pass/fail criteria for reporting
+      report_style: modern   # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -162,7 +162,7 @@
       report_style: modern   # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
-        - BLFE1
+        - BLFE1  # Device on which tests run
     - name: test_
       description: null
       test_id: NRFU5.4

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -154,11 +154,11 @@
       filter:
         - BLFE1
     - name: test_eos_no_config_functionality
-      description: Testcases for verification of security root port EOS no configurations functionality.
+      description: Testcases for verification of security root port "EOS no configurations" functionality.
       test_id: NRFU5.3
       show_cmd: show lldp neighbors detail
       expected_output: null   # Forming expected output dictionary in testcase file
-      test_criteria: Localhost should not found in the LLDP neighbor information on device.   # Setting test case’s pass/fail criteria for reporting
+      test_criteria: Localhost should not be found in the LLDP neighbor information on device.   # Setting test case’s pass/fail criteria for reporting
       report_style: modern   # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -158,7 +158,7 @@
       test_id: NRFU5.3
       show_cmd: show lldp neighbors detail
       expected_output: null   # Forming expected output dictionary in testcase file
-      test_criteria: No localhost should found in LLDP information on device.   # Setting test case’s pass/fail criteria for reporting
+      test_criteria: Localhost should not found in the LLDP neighbor information on device.   # Setting test case’s pass/fail criteria for reporting
       report_style: modern   # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -136,11 +136,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_eos_no_config_functionality
+      description: Testcases for verification of security root port EOS no configurations functionality.
       test_id: NRFU5.3
-      show_cmd: null
+      show_cmd: show lldp neighbors detail
       expected_output: null
+      test_criteria: No localhost should found in LLDP information on device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -141,7 +141,7 @@
       test_id: NRFU5.3
       show_cmd: show lldp neighbors detail
       expected_output: null
-      test_criteria: No localhost should found in LLDP information on device.
+      test_criteria: Localhost should not found in the LLDP neighbor information on device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -137,11 +137,11 @@
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_eos_no_config_functionality
-      description: Testcases for verification of security root port EOS no configurations functionality.
+      description: Testcases for verification of security root port "EOS no configurations" functionality.
       test_id: NRFU5.3
       show_cmd: show lldp neighbors detail
       expected_output: null
-      test_criteria: Localhost should not found in the LLDP neighbor information on device.
+      test_criteria: Localhost should not be found in the LLDP neighbor information on device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_security_rp_eos_no_config_test.py
+++ b/nrfu_tests/test_security_rp_eos_no_config_test.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""Testcases for verification of security root port EOS no configurations functionality"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.security
+class EosNoConfigTests:
+
+    """Testcases for verification of security root port EOS no configurations functionality"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_eos_no_config_functionality"]["duts"]
+    test_ids = dut_parameters["test_eos_no_config_functionality"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_eos_no_config_functionality(self, dut, tests_definitions):
+        """
+        TD: Testcases for verification of security root port EOS no configurations functionality
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.expected_output = {"rp_eos_configurations": {}}
+        tops.actual_output = {"rp_eos_configurations": {}}
+
+        # Forming output message if test result is pass
+        tops.output_msg = "No localhost found in LLDP information on device."
+
+        try:
+            """
+            TS: Running 'show lldp neighbors detail' command and Verifying device is configured
+            successfully with EOS configurations.
+            """
+            lldp_info = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, Output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                lldp_info,
+            )
+            self.output += (
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{lldp_info}\n"
+            )
+            neighbor_details = lldp_info.get("lldpNeighbors")
+            assert neighbor_details, f"lldp neighbor details not found on device {tops.dut_name}."
+
+            for interface, interface_details in lldp_info.get("lldpNeighbors").items():
+                if not interface_details.get("lldpNeighborInfo"):
+                    tops.actual_output["rp_eos_configurations"][interface] = True
+                    tops.expected_output["rp_eos_configurations"][interface] = True
+                    continue
+
+                system_name = interface_details.get("lldpNeighborInfo", [])[0].get("systemName")
+                system_description = interface_details.get("lldpNeighborInfo", [])[0].get(
+                    "systemDescription"
+                )
+                # If details for above keys are not found then skipping the verification part for
+                # the same considering no localhost in configurations.
+                if not system_description or not system_name:
+                    continue
+
+                if system_name == "localhost":
+                    if "Arista" in system_description:
+                        tops.expected_output["rp_eos_configurations"][interface] = True
+                        tops.actual_output["rp_eos_configurations"][interface] = False
+
+            # forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                localhost_found_interfaces = []
+                for interface in tops.actual_output["rp_eos_configurations"]:
+                    if not tops.actual_output["rp_eos_configurations"][interface]:
+                        localhost_found_interfaces.append(interface)
+                tops.output_msg = (
+                    f"\nOn device {tops.dut_name}, following interfaces found with localhost in"
+                    f" LLDP information:\n{', '.join(localhost_found_interfaces)}"
+                )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_eos_no_config_functionality)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_security_rp_eos_no_config_test.py
+++ b/nrfu_tests/test_security_rp_eos_no_config_test.py
@@ -95,7 +95,8 @@ class EosNoConfigTests:
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                f"On device {tops.dut_name}: Error while running the testcase is:\n{tops.actual_output}"
+                f"On device {tops.dut_name}: Error while running the testcase"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_security_rp_eos_no_config_test.py
+++ b/nrfu_tests/test_security_rp_eos_no_config_test.py
@@ -41,8 +41,8 @@ class EosNoConfigTests:
 
         try:
             """
-            TS: Running 'show lldp neighbors detail' command and verifying that localhost should not
-            found on the LLDP neighbor information..
+            TS: Running `show lldp neighbors detail` command and verifying that localhost should not
+            found on the LLDP neighbor information.
             """
             lldp_info = dut["output"][tops.show_cmd]["json"]
             logger.info(
@@ -55,23 +55,22 @@ class EosNoConfigTests:
                 f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{lldp_info}\n"
             )
             neighbor_details = lldp_info.get("lldpNeighbors")
-            assert neighbor_details, "lldp neighbor details not found on device."
+            assert neighbor_details, "LLDP neighbor details are not found on device."
 
-            for interface, interface_details in lldp_info.get("lldpNeighbors").items():
+            for interface, interface_details in neighbor_details.items():
                 tops.actual_output["lldp_neighbor_information"]["interfaces"][interface] = {
                     "localhost_not_found": True
                 }
                 tops.expected_output["lldp_neighbor_information"]["interfaces"][interface] = {
                     "localhost_not_found": True
                 }
-
-                if not interface_details.get("lldpNeighborInfo"):
+                neighbor_info = interface_details.get("lldpNeighborInfo")
+                if not neighbor_info:
                     continue
 
-                system_name = interface_details.get("lldpNeighborInfo", [])[0].get("systemName")
-                system_description = interface_details.get("lldpNeighborInfo", [])[0].get(
-                    "systemDescription"
-                )
+                system_name = neighbor_info[0].get("systemName")
+                system_description = neighbor_info[0].get("systemDescription")
+
                 # If details for above keys are not found then skipping the verification part for
                 # the same considering no localhost in configurations.
                 if not system_description or not system_name:
@@ -92,8 +91,8 @@ class EosNoConfigTests:
                     ]:
                         localhost_found_interfaces.append(interface)
                 tops.output_msg = (
-                    "\nfollowing interfaces found with localhost in"
-                    f" LLDP neighbor information:\n{', '.join(localhost_found_interfaces)}"
+                    "\nFollowing interfaces found with localhost in"
+                    f" LLDP neighbor information: {', '.join(localhost_found_interfaces)}"
                 )
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:

--- a/nrfu_tests/test_security_rp_eos_no_config_test.py
+++ b/nrfu_tests/test_security_rp_eos_no_config_test.py
@@ -5,11 +5,11 @@
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane import tests_tools
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -25,7 +25,7 @@ class EosNoConfigTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_eos_no_config_functionality(self, dut, tests_definitions):
         """
-        TD: Testcases for verification of security root port EOS no configurations functionality
+        TD: Testcases for verification of security root port "EOS no configurations" functionality
         Args:
           dut(dict): Details related to the switches
           tests_definitions(dict): Test suite and test case parameters
@@ -42,14 +42,11 @@ class EosNoConfigTests:
         try:
             """
             TS: Running `show lldp neighbors detail` command and verifying that localhost should not
-            found on the LLDP neighbor information.
+            be found in the LLDP neighbor information.
             """
             lldp_info = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, Output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                lldp_info,
+            logging.info(
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} command is:\n{lldp_info}\n"
             )
             self.output += (
                 f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{lldp_info}\n"
@@ -97,10 +94,8 @@ class EosNoConfigTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s: Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}: Error while running the testcase is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes

test_definition.yaml: Updated test def with testcase NRFU5.3
test_definition.yaml.j2: Updated J2 with testcase NRFU5.3
test_security_rp_eos_no_config_test.py: Added python file for testcase NRFU5.3

# Any specific logic/part of code you need extra attention on

Running 'show lldp neighbors detail' command and verifying that localhost should not found on the LLDP neighbor information.

# Issue_ID: https://github.com/aristanetworks/vane/issues/452

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU Tests)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# Reports

Passed reports when test criteria met(no local host found in lldp details)
[report_passed.docx](https://github.com/aristanetworks/vane/files/12606722/report_passed.docx)



Passed report with j2
[report_passed_j2.docx](https://github.com/aristanetworks/vane/files/12606719/report_passed_j2.docx)




Failed reports when test criteria does not met.(Tested using hardcoded output)
[report_failed.docx](https://github.com/aristanetworks/vane/files/12606717/report_failed.docx)




Assert failed reports when lldp neighbor details not found( Tested using hardcoded output)
[report_assert_failed.docx](https://github.com/aristanetworks/vane/files/12509133/report_assert_failed.docx)



Html reports
[html_report.zip](https://github.com/aristanetworks/vane/files/12606713/html_report.zip)




