### PR TITLE
Issue_423: Convert Pytest-CVP Interface Description test case to Vane #423

### DIFF
--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -3,5 +3,13 @@ global_dut_filter: # This stanza is optional. If it is not provided by users the
   filter:
     - BLFE1
 testcase_data:
+  NRFU2.1:
+    descriptions_to_ignore: # Interfaces to ignore for the following descriptions
+      - unused
+      - available
+      - reserved
+      - test
+      - future
+    fail_on_no_description: True # The Test case will fail if the description is not found, if the trigger is set to true, otherwise test case will be passed for interfaces with a description not found.
   NRFU4.1:
     skip_on_command_unavailable: False # Skip the test case if the command is unavailable when set to True, otherwise check with assert messaging

--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -4,12 +4,12 @@ global_dut_filter: # This stanza is optional. If it is not provided by users the
     - BLFE1
 testcase_data:
   NRFU2.1:
-    descriptions_to_ignore: # Interfaces to ignore for the following descriptions
+    descriptions_to_ignore: # Interfaces to ignore the following descriptions
       - unused
       - available
       - reserved
       - test
       - future
-    fail_on_no_description: True # The Test case will fail if the description is not found, if the trigger is set to true, otherwise test case will be passed for interfaces with a description not found.
+    fail_on_no_description: True # If this field is set to True, the Test case will fail when the description is not found. Otherwise test case will pass even when interfaces do not have a description.
   NRFU4.1:
     skip_on_command_unavailable: False # Skip the test case if the command is unavailable when set to True, otherwise check with assert messaging

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -48,16 +48,16 @@
         - show interfaces description
         - show vlan
       expected_output: null # Forming expected output dynamically in the test file.
-      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have description. # Setting test case’s pass/fail criteria for reporting
+      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have a description. # Setting test case’s pass/fail criteria for reporting
       report_style: modern # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
       input:
-        descriptions_to_ignore: # Interfaces to ignore for the following descriptions
+        descriptions_to_ignore: # Interfaces to ignore the following descriptions
           - unused
           - available
           - reserved
           - test
           - future
-        fail_on_no_description: True # The Test case will fail if the description is not found, if the trigger is set to true, otherwise test case will be passed for interfaces with description not found.
+        fail_on_no_description: True # If this field is set to True, the Test case will fail when the description is not found. Otherwise test case will pass even when interfaces do not have a description.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -41,12 +41,23 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_interfaces_description_status
+      description: Test case for verification of interface description status.
       test_id: NRFU2.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmds:
+        - show interfaces description
+        - show vlan
+      expected_output: null # Forming expected output dynamically in the test file.
+      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have description. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
+      input:
+        descriptions_to_ignore: # Interfaces to ignore for the following descriptions
+          - unused
+          - available
+          - reserved
+          - test
+          - future
+        fail_on_no_description: True # The Test case will fail if the description is not found, if the trigger is set to true, otherwise test case will be passed for interfaces with description not found.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -45,7 +45,7 @@
         - show interfaces description
         - show vlan
       expected_output: null
-      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have description.
+      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have a description.
       report_style: modern
       input:
         descriptions_to_ignore: {{ test_data["descriptions_to_ignore"] }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -37,12 +37,19 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_interfaces_description_status
+      description: Test case for verification of interface description status.
       test_id: NRFU2.1
-      show_cmd: null
+      {% set test_data = testcase_data["NRFU2.1"] %}
+      show_cmds:
+        - show interfaces description
+        - show vlan
       expected_output: null
+      test_criteria: Except for the interfaces with description to ignore, all other interfaces' status should be up and should have description.
       report_style: modern
+      input:
+        descriptions_to_ignore: {{ test_data["descriptions_to_ignore"] }}
+        fail_on_no_description: {{ test_data["fail_on_no_description"] }}
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_interfaces_errdisabled_status

--- a/nrfu_tests/test_interfaces_description_status.py
+++ b/nrfu_tests/test_interfaces_description_status.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test case for verification of interface description status.
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.config import dut_objs, test_defs
+from vane import tests_tools, test_case_logger
+
+TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.interfaces
+class InterfacesDescriptionStatusTests:
+    """
+    Test case for verification of interface description status.
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_interfaces_description_status"]["duts"]
+    test_ids = dut_parameters["test_interfaces_description_status"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_interfaces_description_status(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of interface description status.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+
+        # Collecting test parameters and initializing parameters
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {
+            "interfaces": {
+                "descriptions_to_ignore": [],
+                "descriptions_found": {},
+            }
+        }
+        tops.expected_output = {
+            "interfaces": {
+                "descriptions_to_ignore": [],
+                "descriptions_found": {},
+            }
+        }
+        test_parameters = tops.test_parameters
+        input_parameters = test_parameters["input"]
+        descriptions_to_ignore = input_parameters["descriptions_to_ignore"]
+        fail_on_no_description = input_parameters["fail_on_no_description"]
+        dynamic_vlans = []
+        description_not_found = []
+
+        # Forming output message if the test result is passed
+        tops.output_msg = (
+            "Except for the interfaces with description to ignore, all other interfaces' status is"
+            " up and having description."
+        )
+
+        try:
+            """
+            TS: Running `show interfaces description` command on the device and verifying the
+            interfaces having description and status is up.
+            """
+            interface_output = dut["output"][tops.show_cmds[tops.dut_name][0]]["json"]
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmds[tops.dut_name][0]} command"
+                f" is:\n{interface_output}\n"
+            )
+            self.output += (
+                f"\nOn device {tops.dut_name}, output of {tops.show_cmds[tops.dut_name][0]} command"
+                f" is:\n{interface_output}\n"
+            )
+
+            interfaces = interface_output.get("interfaceDescriptions")
+            assert interfaces, "Interfaces details are not found in the output."
+
+            """
+            TS: Running `show vlan` command on the device and collecting the dynamic vlans from the
+            output.
+            """
+            vlan_output = dut["output"][tops.show_cmds[tops.dut_name][1]]["json"]
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmds[tops.dut_name][1]} command"
+                f" is:\n{vlan_output}\n"
+            )
+            self.output += (
+                f"\nOn device {tops.dut_name}, output of {tops.show_cmds[tops.dut_name][1]} command"
+                f" is:\n{vlan_output}\n"
+            )
+
+            vlans = vlan_output.get("vlans", [])
+
+            # Collecting dynamic VLANs from the output
+            for vlan in vlans:
+                if vlans.get(vlan, {}).get("dynamic"):
+                    dynamic_vlans.append(vlan)
+
+            for interface in interfaces:
+                status = interfaces.get(interface, {}).get("interfaceStatus")
+                description = interfaces.get(interface, {}).get("description")
+
+                # Skipping the interfaces which are dynamic VLANs
+                if interface.lstrip("Vlan") in dynamic_vlans:
+                    continue
+
+                # Flag to check the description is to ignore or not
+                description_to_ignore_flag = any(
+                    description_to_ignore in description.lower()
+                    for description_to_ignore in descriptions_to_ignore
+                )
+
+                # Checking for the interfaces with descriptions is required or not and forming
+                # expected and actual output accordingly.
+                if (description or fail_on_no_description) and not description_to_ignore_flag:
+                    if not description:
+                        tops.expected_output["interfaces"]["descriptions_found"].update(
+                            {interface: {"description_found": True}}
+                        )
+                        tops.actual_output["interfaces"]["descriptions_found"].update(
+                            {interface: {"description_found": False}}
+                        )
+                    else:
+                        tops.expected_output["interfaces"]["descriptions_found"].update(
+                            {interface: {"description": description, "status": "up"}}
+                        )
+                        tops.actual_output["interfaces"]["descriptions_found"].update(
+                            {interface: {"description": description, "status": status}}
+                        )
+                elif description_to_ignore_flag or not fail_on_no_description:
+                    tops.expected_output["interfaces"]["descriptions_to_ignore"].append(interface)
+                    tops.actual_output["interfaces"]["descriptions_to_ignore"].append(interface)
+
+            # Forming output message if the test result is failed
+            if tops.expected_output != tops.actual_output:
+                tops.output_msg = ""
+
+                # Checking if the test case needs to fail or not, based on the description required
+                # or not and forming output messages accordingly.
+                for interface, interface_details in tops.expected_output["interfaces"][
+                    "descriptions_found"
+                ].items():
+                    actual_interface_details = (
+                        tops.actual_output.get("interfaces", {})
+                        .get("descriptions_found", {})
+                        .get(interface, {})
+                    )
+                    if "description" in actual_interface_details.keys():
+                        actual_interface_description = actual_interface_details.get("description")
+                        actual_interface_status = actual_interface_details.get("status")
+                    else:
+                        actual_interface_description = actual_interface_details.get(
+                            "description_found"
+                        )
+                    expected_interface_status = interface_details.get("status")
+
+                    if not actual_interface_description:
+                        description_not_found.append(interface)
+                    elif actual_interface_status != expected_interface_status:
+                        tops.output_msg += (
+                            f"\nFor interface {interface}, expected status is"
+                            f" '{expected_interface_status}', however, actual is found as"
+                            f" '{actual_interface_status}' with description"
+                            f" '{actual_interface_description}'"
+                        )
+
+                if description_not_found:
+                    description_not_found = ", ".join(description_not_found)
+                    tops.output_msg += (
+                        "\nFor the following interfaces expected a description, however, it is"
+                        f" not found:\n{description_not_found}\n"
+                    )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logging.error(
+                f"On device {tops.dut_name}, Error while running the test case"
+                f" is:\n{tops.actual_output}"
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_interfaces_description_status)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_interfaces_description_status.py
+++ b/nrfu_tests/test_interfaces_description_status.py
@@ -59,13 +59,13 @@ class InterfacesDescriptionStatusTests:
         # Forming output message if the test result is passed
         tops.output_msg = (
             "Except for the interfaces with description to ignore, all other interfaces' status is"
-            " up and having description."
+            " up and have a description."
         )
 
         try:
             """
             TS: Running `show interfaces description` command on the device and verifying the
-            interfaces having description and status is up.
+            interfaces have a description and their status is up.
             """
             interface_output = dut["output"][tops.show_cmds[tops.dut_name][0]]["json"]
             logging.info(
@@ -109,15 +109,19 @@ class InterfacesDescriptionStatusTests:
                 if interface.lstrip("Vlan") in dynamic_vlans:
                     continue
 
-                # Flag to check the description is to ignore or not
+                # Flag to check if the description is to be ignored or not
                 description_to_ignore_flag = any(
                     description_to_ignore in description.lower()
                     for description_to_ignore in descriptions_to_ignore
                 )
 
-                # Checking for the interfaces with descriptions is required or not and forming
+                # Checking for the interfaces with description requirements and forming
                 # expected and actual output accordingly.
+                # Checking if the description needs to be ignored or not, with test case fail
+                # condition
                 if (description or fail_on_no_description) and not description_to_ignore_flag:
+                    # Forming actual output based on whether the test case needs to fail when
+                    # description is not found
                     if not description:
                         tops.expected_output["interfaces"]["descriptions_found"].update(
                             {interface: {"description_found": True}}
@@ -125,6 +129,7 @@ class InterfacesDescriptionStatusTests:
                         tops.actual_output["interfaces"]["descriptions_found"].update(
                             {interface: {"description_found": False}}
                         )
+                    # Getting status for the interfaces whose description is found
                     else:
                         tops.expected_output["interfaces"]["descriptions_found"].update(
                             {interface: {"description": description, "status": "up"}}
@@ -140,8 +145,8 @@ class InterfacesDescriptionStatusTests:
             if tops.expected_output != tops.actual_output:
                 tops.output_msg = ""
 
-                # Checking if the test case needs to fail or not, based on the description required
-                # or not and forming output messages accordingly.
+                # Checking if the test case needs to fail or not, based on the description
+                # requirement and forming output messages accordingly.
                 for interface, interface_details in tops.expected_output["interfaces"][
                     "descriptions_found"
                 ].items():
@@ -172,7 +177,7 @@ class InterfacesDescriptionStatusTests:
                 if description_not_found:
                     description_not_found = ", ".join(description_not_found)
                     tops.output_msg += (
-                        "\nFor the following interfaces expected a description, however, it is"
+                        "\nFor the following interfaces description was expected, however, it is"
                         f" not found:\n{description_not_found}\n"
                     )
 


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_interfaces_description_status.py as per the vane style guide along with the updated following files.
test_definition.yaml: Updated test def with testcase NRFU2.1
test_definition.yaml.j2: Updated J2 with testcase NRFU2.1
masterdef.yaml: Added master def yaml for DUTs
nrfu_tests/test_interfaces_description_status.py: Added converted testsuite file for testcases NRFU2.1

# Any specific logic/part of code you need extra attention on

From the output of **show interfaces description**, verified that the all interface with description to verify having description and status as up, the interfaces with description to ignore having status as up, if interfaces or Vlans are not found then testcase will skip.

# Include the Issue number and link

#423 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU testcase)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?

Unit tests:

Tested the test_interfaces_description_status for all status as up and proper description where needed: Test case passed
[pass_report.docx](https://github.com/aristanetworks/vane/files/12647342/pass_report.docx)

Tested the test_interfaces_description_status for all status as up and proper description where needed with j2 format: Test case passed
[pass_report_j2.docx](https://github.com/aristanetworks/vane/files/12647344/pass_report_j2.docx)

Tested the test_interfaces_description_status for all status as up and when failOnNoDescription is False: Test case passed
[pass_report_fail_on_no_description_FALSE.docx](https://github.com/aristanetworks/vane/files/12647348/pass_report_fail_on_no_description_FALSE.docx)

Tested the test_interfaces_description_status for descriptions to ignore: Test case passed
[pass_report_interface_with_description_to_ignore_down.docx](https://github.com/aristanetworks/vane/files/12647349/pass_report_interface_with_description_to_ignore_down.docx)

Tested the test_interfaces_description_status for no description for description to verify: Test case failed
[fail_report_interface_not_having_description.docx](https://github.com/aristanetworks/vane/files/12647352/fail_report_interface_not_having_description.docx)

Tested the test_interfaces_description_status for down status and no description when failOnNoDescription is True: Test case failed
[fail_report_interface_wrong_status_no_description.docx](https://github.com/aristanetworks/vane/files/12647354/fail_report_interface_wrong_status_no_description.docx)

Tested the test_interfaces_description_status for wrong status: Test case failed
[fail_report_wrong_status.docx](https://github.com/aristanetworks/vane/files/12647357/fail_report_wrong_status.docx)

Tested the test_interfaces_description_status for Interface output not found (Used hardcoded output): Test case failed with assertion message
[assert_fail_interface_output_not_found_hardcoded.docx](https://github.com/aristanetworks/vane/files/12647360/assert_fail_interface_output_not_found_hardcoded.docx)

HTML Reports:
[html reports.zip](https://github.com/aristanetworks/vane/files/12647361/html.reports.zip)