### PR TITLE
Issue-436:Convert Pytest-CVP Login Banner test case to Vane #436

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -171,12 +171,14 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_security_rp_login_banner
+      description: Testcase for verification of login banner.
       test_id: NRFU5.5
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show banner login
+      expected_output:
+        login_banner_found: True
+      test_criteria: Login banner should be found on the device. # Setting test case’s pass / fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -152,11 +152,13 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_security_rp_login_banner
+      description: Testcase for verification of login banner.
       test_id: NRFU5.5
-      show_cmd: null
-      expected_output: null
+      show_cmd: show banner login
+      expected_output:
+       login_banner_found: True
+      test_criteria: Login banner should be found on the device.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -59,7 +59,7 @@ class LoginBannerTests:
             # forming output message if test result is fail
             if tops.expected_output != tops.actual_output:
                 if not tops.actual_output["login_banner_found"]:
-                    tops.output_msg = "\nLogin banner is not found on the device."
+                    tops.output_msg = "Login banner is not found on the device."
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -2,7 +2,7 @@
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
-Testcase for verification of login banner is configured.
+Testcase for verification of security rp login banner
 """
 
 import pytest
@@ -18,7 +18,7 @@ TEST_SUITE = "nrfu_tests"
 @pytest.mark.security
 class SecurityRpLoginBannerTests:
     """
-    Testcase for verification of login banner is configured.
+    Testcase for verification of security rp login banner
     """
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -28,7 +28,7 @@ class SecurityRpLoginBannerTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_security_rp_login_banner(self, dut, tests_definitions):
         """
-        TD: Testcase for verification of login banner is configured.
+        TD: Testcase for verification of security rp login banner
         Args:
             dut(dict): details related to a particular DUT
             tests_definitions(dict): test suite and test case parameters
@@ -42,7 +42,7 @@ class SecurityRpLoginBannerTests:
 
         try:
             """
-            TS: Running `show banner login` command on a DUT and verifying that the
+            TS: Running `show banner login` command on device and verifying that the expected
             login banner is correct.
             """
             output = dut["output"][tops.show_cmd]["json"]
@@ -61,7 +61,9 @@ class SecurityRpLoginBannerTests:
             # forming output message if test result is fail
             if tops.expected_output != tops.actual_output:
                 if not tops.actual_output["login_banner_found"]:
-                    tops.output_msg = f"Login banner is not configured on {tops.dut_name}"
+                    tops.output_msg = (
+                        f"\nExpected login banner is not configured on {tops.dut_name}."
+                    )
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Testcase for verification of login banner is configured.
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.security
+class SecurityRpLoginBannerTests:
+    """
+    Testcase for verification of login banner is configured.
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_security_rp_login_banner"]["duts"]
+    test_ids = dut_parameters["test_security_rp_login_banner"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_security_rp_login_banner(self, dut, tests_definitions):
+        """
+        TD: Testcase for verification of login banner is configured.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {"login_banner_found": False}
+
+        # Forming output message if test result is passed
+        tops.output_msg = "Expected login banner is present on the switch."
+
+        try:
+            """
+            TS: Running `show banner login` command on a DUT and verifying that the
+            login banner is correct.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is: \n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output += f"\nOutput of {tops.show_cmd} command is: \n{output}"
+            login_banner = output.get("loginBanner")
+
+            if login_banner:
+                tops.actual_output = {"login_banner_found": True}
+
+            # forming output message if test result is fail
+            if tops.expected_output != tops.actual_output:
+                if not tops.actual_output["login_banner_found"]:
+                    tops.output_msg = f"Login banner is not configured on {tops.dut_name}"
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_security_rp_login_banner)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -16,7 +16,7 @@ TEST_SUITE = "nrfu_tests"
 
 @pytest.mark.nrfu_test
 @pytest.mark.security
-class SecurityRpLoginBannerTests:
+class LoginBannerTests:
     """
     Testcase for verification of security rp login banner
     """
@@ -38,12 +38,12 @@ class SecurityRpLoginBannerTests:
         tops.actual_output = {"login_banner_found": False}
 
         # Forming output message if test result is passed
-        tops.output_msg = "Expected login banner is present on the switch."
+        tops.output_msg = "Login banner is found on the device."
 
         try:
             """
-            TS: Running `show banner login` command on device and verifying that the expected
-            login banner is correct.
+            TS: Running `show banner login` command on device and verifying that the
+            login banner is found on the device.
             """
             output = dut["output"][tops.show_cmd]["json"]
             logger.info(
@@ -54,16 +54,12 @@ class SecurityRpLoginBannerTests:
             )
             self.output += f"\nOutput of {tops.show_cmd} command is: \n{output}"
             login_banner = output.get("loginBanner")
-
-            if login_banner:
-                tops.actual_output = {"login_banner_found": True}
+            tops.actual_output = {"login_banner_found": bool(login_banner)}
 
             # forming output message if test result is fail
             if tops.expected_output != tops.actual_output:
                 if not tops.actual_output["login_banner_found"]:
-                    tops.output_msg = (
-                        f"\nExpected login banner is not configured on {tops.dut_name}."
-                    )
+                    tops.output_msg = "\nLogin banner is not found on the device."
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -61,7 +61,7 @@ class LoginBannerTests:
                 if not tops.actual_output["login_banner_found"]:
                     tops.output_msg = "Login banner is not found on the device."
 
-        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+        except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logger.error(
                 "On device %s, Error while running the testcase is:\n%s",

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -2,7 +2,7 @@
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
-Testcase for verification of security rp login banner
+Testcase for verification of login banner
 """
 
 import pytest
@@ -18,7 +18,7 @@ TEST_SUITE = "nrfu_tests"
 @pytest.mark.security
 class LoginBannerTests:
     """
-    Testcase for verification of security rp login banner
+    Testcase for verification of login banner
     """
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -28,7 +28,7 @@ class LoginBannerTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_security_rp_login_banner(self, dut, tests_definitions):
         """
-        TD: Testcase for verification of security rp login banner
+        TD: Testcase for verification of login banner.
         Args:
             dut(dict): details related to a particular DUT
             tests_definitions(dict): test suite and test case parameters

--- a/nrfu_tests/test_security_rp_login_banner.py
+++ b/nrfu_tests/test_security_rp_login_banner.py
@@ -7,11 +7,11 @@ Testcase for verification of login banner
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -46,11 +46,8 @@ class LoginBannerTests:
             login banner is found on the device.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is: \n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is: \n{output}\n",
             )
             self.output += f"\nOutput of {tops.show_cmd} command is: \n{output}"
             login_banner = output.get("loginBanner")
@@ -63,10 +60,11 @@ class LoginBannerTests:
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                (
+                    f"On device {tops.dut_name}, Error while running the testcase"
+                    f" is:\n{tops.actual_output}"
+                ),
             )
 
         tops.test_result = tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes
CDescribe the solution you'd like
PyTest-CVP Login Banner test case should have the following:

Use Vane test case styling
Use Master definition file to simplify input
Add test case steps to the test case
Test should be added to top-level directory nrfu_tests
Use markers nrfu_test, security
Use Test ID: NRFU5.5

# Any specific logic/part of code you need extra attention on
 From the output of  'show banner login' and verifying that the login banner is correct.


# Include the Issue number and link
#436 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU Testcase)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Unit Tests:

- Tested for all the verifying that the login banner is correct.: Passed

[PASS-436-NEW.docx](https://github.com/aristanetworks/vane/files/12519095/PASS-436-NEW.docx)


- Tested if login banner is not enabled on switch: Failed.
 
[FAIL-436-NEW.docx](https://github.com/aristanetworks/vane/files/12519093/FAIL-436-NEW.docx)


- Tested  for verifying that the login banner is correct: Passed (With generate test definition True and J2 True )
   
[PASS-436-NEW-WITH-J2.docx](https://github.com/aristanetworks/vane/files/12519092/PASS-436-NEW-WITH-J2.docx)


HTML reports:

[HTML-436-NEW.zip](https://github.com/aristanetworks/vane/files/12519091/HTML-436-NEW.zip)


-Pass report after adding logging and f-string changes.

[436-PASS-AFTER-LOGGING.docx](https://github.com/aristanetworks/vane/files/12606311/436-PASS-AFTER-LOGGING.docx)

[436-PASS-AFTER-LOGGING.zip](https://github.com/aristanetworks/vane/files/12606321/436-PASS-AFTER-LOGGING.zip)


## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
