### PR TITLE
Issue_439: Convert Pytest-CVP Username No Password test case to Vane #439

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -201,12 +201,13 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_security_rp_username_password
+      description: Test case for verification of password configuration for user accounts.
       test_id: NRFU5.8
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show running-config all section ^username
+      expected_output: null # Forming expected output dynamically in test case file.
+      test_criteria: All user accounts should be configured with a password. # Setting test case’s pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -205,9 +205,9 @@
       description: Test case for verification of password configuration for user accounts.
       test_id: NRFU5.8
       show_cmd: show running-config all section ^username
-      expected_output: null # Forming expected output dynamically in test case file.
+      expected_output: null # Forming expected output dynamically in the test case file.
       test_criteria: All user accounts should be configured with a password. # Setting test case’s pass/fail criteria for reporting
-      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
+      report_style: modern # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -179,11 +179,12 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_security_rp_username_password
+      description: Test case for verification of password configuration for user accounts.
       test_id: NRFU5.8
-      show_cmd: null
+      show_cmd: show running-config all section ^username
       expected_output: null
+      test_criteria: All user accounts should be configured with a password.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_security_rp_username_password.py
+++ b/nrfu_tests/test_security_rp_username_password.py
@@ -43,8 +43,8 @@ class UsernamePasswordTests:
 
         try:
             """
-            TS: Running `show running-config all section ^username` command on the device and verifying
-            all usernames are configured with a password.
+            TS: Running `show running-config all section ^username` command on the device and
+            verifying all usernames are configured with a password.
             """
             output = dut["output"][tops.show_cmd]["text"]
             logging.info(

--- a/nrfu_tests/test_security_rp_username_password.py
+++ b/nrfu_tests/test_security_rp_username_password.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test case for verification of password configuration for user accounts.
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.security
+class UsernamePasswordTests:
+    """
+    Test case for verification of password configuration for user accounts.
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_security_rp_username_password"]["duts"]
+    test_ids = dut_parameters["test_security_rp_username_password"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_security_rp_username_password(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of password configuration for user accounts.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.actual_output = {}
+        tops.expected_output = {}
+
+        # Forming output message if test result is passed
+        tops.output_msg = "All user accounts are configured with a password."
+
+        try:
+            """
+            TS: Running `show running-config all section ^username` command on device and verifying
+            all usernames are configured with a password.
+            """
+            output = dut["output"][tops.show_cmd]["text"]
+            logger.info(
+                "On device %s, output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output += (
+                f"\nOn device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
+            )
+            assert output, "User account details are not found in the output."
+
+            # Collecting username and password for each user accounts and
+            # creating expected and actual output dictionaries
+            usernames = output.split("\n")
+            for user in usernames:
+                if user:
+                    username = user.split()[1]
+                    password = user.split()[-1]
+                    tops.expected_output.update({username: {"password_configured": True}})
+                    tops.actual_output.update({username: {"password_configured": True}})
+                    if password == "nopassword":
+                        tops.actual_output.update({username: {"password_configured": False}})
+
+            # Forming output message if test result is failed
+            if tops.expected_output != tops.actual_output:
+                tops.output_msg = "\n"
+                password_not_configured = []
+
+                # Collecting usernames for which password is not configured
+                for username in tops.expected_output:
+                    actual_username_detail = tops.actual_output.get(username, {}).get(
+                        "password_configured"
+                    )
+                    if not actual_username_detail:
+                        password_not_configured.append(username)
+                if password_not_configured:
+                    tops.output_msg += (
+                        "Following user accounts are not configured with a"
+                        f" password: {', '.join(password_not_configured)}"
+                    )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_security_rp_username_password)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_security_rp_username_password.py
+++ b/nrfu_tests/test_security_rp_username_password.py
@@ -88,7 +88,8 @@ class UsernamePasswordTests:
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                f"On device {tops.dut_name}, Error while running the test case is:\n{tops.actual_output}"
+                f"On device {tops.dut_name}, Error while running the test case"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_security_rp_username_password.py
+++ b/nrfu_tests/test_security_rp_username_password.py
@@ -7,11 +7,11 @@ Test case for verification of password configuration for user accounts.
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
+from vane import tests_tools, test_case_logger
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -38,27 +38,24 @@ class UsernamePasswordTests:
         tops.actual_output = {}
         tops.expected_output = {}
 
-        # Forming output message if test result is passed
+        # Forming output message if the test result is passed
         tops.output_msg = "All user accounts are configured with a password."
 
         try:
             """
-            TS: Running `show running-config all section ^username` command on device and verifying
+            TS: Running `show running-config all section ^username` command on the device and verifying
             all usernames are configured with a password.
             """
             output = dut["output"][tops.show_cmd]["text"]
-            logger.info(
-                "On device %s, output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
             )
             self.output += (
                 f"\nOn device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
             )
             assert output, "User account details are not found in the output."
 
-            # Collecting username and password for each user accounts and
+            # Collecting username and password for each user account and
             # creating expected and actual output dictionaries
             usernames = output.split("\n")
             for user in usernames:
@@ -70,7 +67,7 @@ class UsernamePasswordTests:
                     if password == "nopassword":
                         tops.actual_output.update({username: {"password_configured": False}})
 
-            # Forming output message if test result is failed
+            # Forming output message if the test result is failed
             if tops.expected_output != tops.actual_output:
                 tops.output_msg = "\n"
                 password_not_configured = []
@@ -90,10 +87,8 @@ class UsernamePasswordTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                f"On device {tops.dut_name}, Error while running the test case is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_security_rp_username_password.py as per the vane style guide along with the updated following files.
test_definition.yaml: Updated test def with testcase NRFU5.8
test_definition.yaml.j2: Updated J2 with testcase NRFU5.8
nrfu_tests/test_security_rp_username_password.py: Added converted testsuite file for testcases NRFU5.8

# Any specific logic/part of code you need extra attention on

From the output of show running-config all section ^username, verified that the all username configured with a password , if usernames are not found then testcase will skip.

# Include the Issue number and link

#439 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU test case)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?

Unit tests:

Tested test_security_rp_username_password with username have password configured: Test case passed
[pass_report.docx](https://github.com/aristanetworks/vane/files/12542207/pass_report.docx)

Tested test_security_rp_username_password with username have password configured using j2 test definition: Test case passed
[pass_report_j2.docx](https://github.com/aristanetworks/vane/files/12542209/pass_report_j2.docx)

Tested test_security_rp_username_password with username are not configured with password: Test case failed
[fail_report.docx](https://github.com/aristanetworks/vane/files/12542213/fail_report.docx)

Tested test_security_rp_username_password with usernames are not found (Used hardcoded output): Test case failed with assertion message
[assert_fail_no_username_found.docx](https://github.com/aristanetworks/vane/files/12542216/assert_fail_no_username_found.docx)

HTML files:
[html report.zip](https://github.com/aristanetworks/vane/files/12542218/html.report.zip)