### PR TITLE
Added TC for NRFU4.3 EVPN L2 VNI routes details verification

### DIFF
--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -23,5 +23,4 @@ testcase_data:
   NRFU6.1:
     days_of_logs: 7 # Number of days used in show logging command
   NRFU4.3:
-    vxlan_interface: Vxlan1   # Configured vxlan interface name
-    skip_on_command_unavailable_check: False  # If you need to skip the testcase on command unavailable, change this to True
+    skip_on_command_unavailable_check: False  # If you need to skip the testcase on 'show bgp evpn summary' command unavailable, change this to True

--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -22,3 +22,5 @@ testcase_data:
       fail_on_missing_linecard_card_slots: False
   NRFU6.1:
     days_of_logs: 7 # Number of days used in show logging command
+  NRFU4.3:
+    vxlan_interface: Vxlan1

--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -23,4 +23,5 @@ testcase_data:
   NRFU6.1:
     days_of_logs: 7 # Number of days used in show logging command
   NRFU4.3:
-    vxlan_interface: Vxlan1
+    vxlan_interface: Vxlan1   # Configured vxlan interface name
+    skip_on_command_unavailable_check: False  # If you need to skip the testcase on command unavailable, change this to True

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -150,12 +150,15 @@
       criteria: names # Criteria to run the test case.
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_routing_evpn_l2vni_imet
+      description: Test case for verification of L2 VNI VXLAN interface functionality.
       test_id: NRFU4.3
       show_cmd: null
       expected_output: null
+      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
       report_style: modern
+      input:
+        vxlan_interface: Vxlan1
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -161,7 +161,7 @@
         skip_on_command_unavailable_check: False   # If you need to skip the testcase on 'show bgp evpn summary' command unavailable, change this to True
       criteria: names
       filter:
-        - DLFW3  # Device on which tests run
+        - BLFE1  # Device on which tests run
     - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -158,8 +158,7 @@
       test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.    # Setting test case’s pass/fail criteria for reporting
       report_style: modern   # Setting report_style as modern. If report type is set as modern then it will update steps, assumptions, external systems in docx report
       input:
-        vxlan_interface: Vxlan1   # Configured vxlan interface name
-      skip_on_command_unavailable_check: False   # If you need to skip the testcase on command unavailable, change this to True
+        skip_on_command_unavailable_check: False   # If you need to skip the testcase on 'show bgp evpn summary' command unavailable, change this to True
       criteria: names
       filter:
         - DLFW3  # Device on which tests run

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -153,15 +153,16 @@
     - name: test_routing_evpn_l2vni_imet
       description: Test case for verification of L2 VNI VXLAN interface functionality.
       test_id: NRFU4.3
-      show_cmd: null
-      expected_output: null
-      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
-      report_style: modern
+      show_cmd: null   # Forming show commands in test file.
+      expected_output: null  # Forming expected output dictionary in test file.
+      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.    # Setting test case’s pass/fail criteria for reporting
+      report_style: modern   # Setting report_style as modern. If report type is set as modern then it will update steps, assumptions, external systems in docx report
       input:
-        vxlan_interface: Vxlan1
+        vxlan_interface: Vxlan1   # Configured vxlan interface name
+      skip_on_command_unavailable_check: False   # If you need to skip the testcase on command unavailable, change this to True
       criteria: names
       filter:
-        - BLFE1
+        - DLFW3  # Device on which tests run
     - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -138,18 +138,17 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_routing_evpn_l2vni_imet
-      description: Test case for verification of L2 VNI VXLAN interface functionality.
-      test_id: NRFU4.3
-      show_cmd: null
-      expected_output: null
-      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
-      report_style: modern
-      input:
-        vxlan_interface: {{ testcase_data["NRFU4.3"]["vxlan_interface"] }}
+  - name: test_routing_evpn_l2vni_imet
+    description: Test case for verification of L2 VNI VXLAN interface functionality.
+    test_id: NRFU4.3
+    show_cmd: null
+    expected_output: null
+    test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
+    report_style: modern
+    input:
       skip_on_command_unavailable_check: {{ testcase_data["NRFU4.3"]["skip_on_command_unavailable_check"] }}
-      criteria: {{ global_dut_filter.criteria }}
-      filter: {{ global_dut_filter.filter }}
+    criteria: {{ global_dut_filter.criteria }}
+    filter: {{ global_dut_filter.filter }}
     - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -146,7 +146,8 @@
       test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
       report_style: modern
       input:
-      vxlan_interface: {{ testcase_data["NRFU4.3"]["vxlan_interface"] }}
+        vxlan_interface: {{ testcase_data["NRFU4.3"]["vxlan_interface"] }}
+      skip_on_command_unavailable_check: {{ testcase_data["NRFU4.3"]["skip_on_command_unavailable_check"] }}
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_multi_agent_routing_protocol

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -138,12 +138,15 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_routing_evpn_l2vni_imet
+      description: Test case for verification of L2 VNI VXLAN interface functionality.
       test_id: NRFU4.3
       show_cmd: null
       expected_output: null
+      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
       report_style: modern
+      input:
+      vxlan_interface: {{ testcase_data["NRFU4.3"]["vxlan_interface"] }}
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_multi_agent_routing_protocol

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -138,17 +138,17 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-  - name: test_routing_evpn_l2vni_imet
-    description: Test case for verification of L2 VNI VXLAN interface functionality.
-    test_id: NRFU4.3
-    show_cmd: null
-    expected_output: null
-    test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
-    report_style: modern
-    input:
-      skip_on_command_unavailable_check: {{ testcase_data["NRFU4.3"]["skip_on_command_unavailable_check"] }}
-    criteria: {{ global_dut_filter.criteria }}
-    filter: {{ global_dut_filter.filter }}
+    - name: test_routing_evpn_l2vni_imet
+      description: Test case for verification of L2 VNI VXLAN interface functionality.
+      test_id: NRFU4.3
+      show_cmd: null
+      expected_output: null
+      test_criteria: Inclusive multicast Ethernet tag (IMET) routes should advertised for all VNI identifiers on device.
+      report_style: modern
+      input:
+        skip_on_command_unavailable_check: {{ testcase_data["NRFU4.3"]["skip_on_command_unavailable_check"] }}
+      criteria: {{ global_dut_filter.criteria }}
+      filter: {{ global_dut_filter.filter }}
     - name: test_multi_agent_routing_protocol
       description: Test case for verification of multi-agent routing model functionality.
       test_id: NRFU4.4

--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""Test case for verification of L2 VNI VXLAN interface functionality"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane import tests_tools
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.routing
+class EvpnRoutingTests:
+
+    """Test case for verification of L2 VNI VXLAN interface functionality"""
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_routing_evpn_l2vni_imet"]["duts"]
+    test_ids = dut_parameters["test_routing_evpn_l2vni_imet"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_routing_evpn_l2vni_imet(self, dut, tests_definitions):
+        """
+        TD: Test case for verification of L2 VNI VXLAN interface functionality.
+        Args:
+          dut(dict): Details related to the switches
+          tests_definitions(dict): Test suite and test case parameters
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        tops.expected_output = {"vrfs": {}}
+        tops.actual_output = {"vrfs": {}}
+        vxlan_interface = tops.test_parameters["input"]["vxlan_interface"]
+
+        # Forming output message if test result is pass
+        tops.output_msg = (
+            "Inclusive multicast Ethernet tag (IMET) routes are advertised for all VNI identifiers"
+            " on device."
+        )
+
+        try:
+            """
+            TS: Running `show bgp evpn summary` command and verifying EVPN is configured
+            on the device.
+            """
+            evpn_summary = tops.run_show_cmds(["show bgp evpn summary"])
+            logger.info(
+                "On device %s, Output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                evpn_summary,
+            )
+            self.output += (
+                f"On device {tops.dut_name}, Output of {tops.show_cmd} is:\n{evpn_summary}\n"
+            )
+            vrf_details = evpn_summary[0]["result"].get("vrfs")
+            assert vrf_details, "VRF details are not found in EVPN bgp route summary."
+
+            evpn_running = False
+            for vrf in vrf_details:
+                if vrf_details[vrf].get("peers"):
+                    evpn_running = True
+                    break
+
+            assert evpn_running, "EVPN is not configured on the device."
+
+            bgp_evpn_peer = ""
+            for vrf in vrf_details:
+                tops.actual_output["vrfs"][vrf] = {"virtual_network_identifiers": {}}
+                tops.expected_output["vrfs"][vrf] = {"virtual_network_identifiers": {}}
+                for peer in vrf_details[vrf].get("peers"):
+                    peer_state = vrf_details[vrf].get("peers")[peer].get("peerState")
+                    if peer_state == "Established":
+                        bgp_evpn_peer = peer
+                        break
+
+                assert bgp_evpn_peer, "No established EVPN peer found."
+
+                """
+                TS: Running `show interfaces <vxlan interface>` command and verifying L2 VNIs are
+                configured on the device.
+                """
+                show_vxlan_command = f"show interfaces {vxlan_interface}"
+                vxlan_details = tops.run_show_cmds([show_vxlan_command])
+                logger.info(
+                    "On device %s, Output of %s command is:\n%s\n",
+                    tops.dut_name,
+                    show_vxlan_command,
+                    vxlan_details,
+                )
+                self.output += (
+                    f"On device {tops.dut_name}, Output of"
+                    f" {show_vxlan_command} is:\n{vxlan_details}\n"
+                )
+                vxlan_details = (
+                    vxlan_details[0]["result"]
+                    .get("interfaces", {})
+                    .get(vxlan_interface, {})
+                    .get("vlanToVniMap")
+                )
+                assert vxlan_details, "No vlan to VNI mapping found in vxlan command details."
+
+                for vlan in vxlan_details:
+                    if not vxlan_details[vlan].get("source"):
+                        vni = vxlan_details[vlan].get("vni")
+                        tops.expected_output["vrfs"][vrf]["virtual_network_identifiers"][
+                            str(vni)
+                        ] = {"imet_routes_being_advertised": True}
+
+                        """
+                        TS: Running `show bgp neighbors <bgp evpn peer> evpn advertised-routes
+                        route-type imet vni <vni>` command and verifying EVPN is configured
+                        on the device.
+                        """
+                        route_show_command = (
+                            f"show bgp neighbors {bgp_evpn_peer} evpn advertised-routes route-type"
+                            f" imet vni {vni}"
+                        )
+                        advertised_route_details = tops.run_show_cmds([route_show_command])
+                        logger.info(
+                            "On device %s, Output of %s command is:\n%s\n",
+                            tops.dut_name,
+                            route_show_command,
+                            advertised_route_details,
+                        )
+                        self.output += (
+                            f"On device {tops.dut_name}, Output of"
+                            f" {show_vxlan_command} is:\n{advertised_route_details}\n"
+                        )
+                        advertised_route_details = advertised_route_details[0]["result"].get(
+                            "evpnRoutes"
+                        )
+
+                        tops.actual_output["vrfs"][vrf]["virtual_network_identifiers"][str(vni)] = {
+                            "imet_routes_being_advertised": bool(advertised_route_details)
+                        }
+
+            # forming output message if test result is fail
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = "\n"
+                for vrf in tops.actual_output["vrfs"]:
+                    no_imet_routes_advertised = []
+                    for vni in tops.actual_output["vrfs"][vrf]["virtual_network_identifiers"]:
+                        if not tops.actual_output["vrfs"][vrf]["virtual_network_identifiers"][vni][
+                            "imet_routes_being_advertised"
+                        ]:
+                            no_imet_routes_advertised.append(vni)
+                    if no_imet_routes_advertised:
+                        tops.output_msg += (
+                            f"For vrf {vrf}, following VNIs has no IMET routes being"
+                            f" advertised:\n{', '.join(no_imet_routes_advertised)}\n"
+                        )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            if "Not supported" in str(excep):
+                tops.output_msg = "Command unavailable, device might be in ribd mode."
+                pytest.skip(
+                    "Command unavailable, device might be in ribd mode. hence test skipped."
+                )
+
+            tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s: Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_routing_evpn_l2vni_imet)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -155,7 +155,7 @@ class EvpnRoutingTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             if skip_on_command_unavailable_check:
-                if excep == EapiError:
+                if (show_bgp_command and "Not supported") in str(excep):
                     tops.output_msg = (
                         f"{show_bgp_command} command unavailable, device might be in ribd mode."
                     )


### PR DESCRIPTION
# Please include a summary of the changes

test_definition.yaml: Updated test def with testcase NRFU4.3
test_definition.yaml.j2: Updated J2 with testcase NRFU4.3
master_def.yaml: Updated master def file for NRFU4.3
test_routing_evpn_l2vni_imet.py: Added python file for testcase NRFU4.3


# Any specific logic/part of code you need extra attention on

Running `show bgp evpn summary` command and verifying EVPN is configured on the device also
Running `show interfaces <vxlan interface>` command and verifying L2 VNIs are configured on the device

# Issue_ID: https://github.com/aristanetworks/vane/issues/432

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU Tests)

# Effort required on reviewers end

- - [ ] Easy
- - [X] Medium
- - [ ] Hard 

# Reports

Passed reports when EVPN routes are advertised for all VNIs
[report_passed.docx](https://github.com/aristanetworks/vane/files/12605931/report_passed.docx)




Passed report using J2.
[report_passed_j2.docx](https://github.com/aristanetworks/vane/files/12605932/report_passed_j2.docx)




Failed reports when test criteria does not met( tested using hardcoded output)
[report_failed.docx](https://github.com/aristanetworks/vane/files/12520890/report_failed.docx)



Skipped reports when ribd model protocol is enabled. EVPN is not configured
[report_skipped_when_device_is_ribd_mode.docx](https://github.com/aristanetworks/vane/files/12520879/report_skipped_when_device_is_ribd_mode.docx)




Failed reports when ribd model protocol is enabled. EVPN is not configured. skip check is false.
[report_failed_when_device_is_ribd_mode.docx](https://github.com/aristanetworks/vane/files/12520864/report_failed_when_device_is_ribd_mode.docx)


Failed assert report when command output not found. VLAN to VNI mapping does not exists. ( Tested using hardcoded output)
[report_assert_failed.docx](https://github.com/aristanetworks/vane/files/12513340/report_assert_failed.docx)


Skipped reports when vxlan not configured.
[report_skipped_when_vxlan_not_configured.docx](https://github.com/aristanetworks/vane/files/12520852/report_skipped_when_vxlan_not_configured.docx)

Failedreport when EVPN is not configured.
[report_failed_when_evpn_not_running.docx](https://github.com/aristanetworks/vane/files/12605928/report_failed_when_evpn_not_running.docx)




Html Reports
[html_report.zip](https://github.com/aristanetworks/vane/files/12605918/html_report.zip)





