### PR TITLE
issue_429: Converted Pytest-CVP misc show test case to Vane #429

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -91,12 +91,12 @@
       filter:
         - BLFE1
     - name: test_misc_show_commands
-      description: Testcase for verification of misc show commands.
+      description: Testcase for verification of miscellaneous show commands support.
       test_id: NRFU3.1
-      show_cmd: null
-      expected_output: null
-      test_criteria: Show commands should be ran successfully on the device.
-      report_style: modern
+      show_cmd: null # Forming show command in test case file.
+      expected_output: null # Forming expected output in test case file.
+      test_criteria: Show commands should be executed on device without any error. # Setting test case’s pass / fail criteria for reporting.
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -310,5 +310,3 @@
       criteria: names
       filter:
         - BLFE1
-=======
->>>>>>> 1f00236 (issue_429:formmatting test def)

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -95,7 +95,7 @@
       test_id: NRFU3.1
       show_cmd: null # Forming show command in test case file.
       expected_output: null # Forming expected output in test case file.
-      test_criteria: Show commands should be executed on device without any error. # Setting test case’s pass / fail criteria for reporting.
+      test_criteria: Show commands should be executed on device without any error. # Setting test case’s pass/fail criteria for reporting.
       report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
@@ -310,3 +310,5 @@
       criteria: names
       filter:
         - BLFE1
+=======
+>>>>>>> 1f00236 (issue_429:formmatting test def)

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -90,11 +90,12 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_misc_show_commands
+      description: Testcase for verification of misc show commands.
       test_id: NRFU3.1
       show_cmd: null
       expected_output: null
+      test_criteria: Show commands should be ran successfully on the device.
       report_style: modern
       criteria: names
       filter:

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -93,10 +93,10 @@
     - name: test_misc_show_commands
       description: Testcase for verification of miscellaneous show commands support.
       test_id: NRFU3.1
-      show_cmd: null # Forming show command in test case file.
-      expected_output: null # Forming expected output in test case file.
-      test_criteria: Show commands should be executed on device without any error. # Setting test case’s pass/fail criteria for reporting.
-      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      show_cmd: null # Forming show command in the test case file.
+      expected_output: null # Forming expected output in the test case file.
+      test_criteria: Show commands should be executed on the device without any error. # Setting test case’s pass/fail criteria for reporting.
+      report_style: modern # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -83,13 +83,13 @@
     - name: test_misc_show_commands
       description: Testcase for verification of miscellaneous show commands support.
       test_id: NRFU3.1
-      # Forming show command in test case file.
+      # Forming show command in the test case file.
       show_cmd: null
-      # Forming expected output in test case file.
+      # Forming expected output in the test case file.
       expected_output: null
       # Setting test case’s pass/fail criteria for reporting.
-      test_criteria: Show commands should be executed on device without any error.
-      # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      test_criteria: Show commands should be executed on the device without any error.
+      # Setting report_style as modern If the report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -81,7 +81,7 @@
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_misc_show_commands
-      description: Testcase for verification of misc show commands.
+      description: Testcase for verification of miscellaneous show commands support.
       test_id: NRFU3.1
       # Forming show command in test case file.
       show_cmd: null

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -278,3 +278,5 @@
       show_cmd: null
       expected_output: null
       report_style: modern
+      criteria: {{ global_dut_filter.criteria }}
+      filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -83,6 +83,7 @@
     - name: test_misc_show_commands
       description: Testcase for verification of misc show commands.
       test_id: NRFU3.1
+      # Forming show command in test case file.
       show_cmd: null
       # Forming expected output in test case file.
       expected_output: null

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -80,11 +80,15 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_misc_show_commands
+      description: Testcase for verification of misc show commands.
       test_id: NRFU3.1
       show_cmd: null
+      # Forming expected output in test case file.
       expected_output: null
+      # Setting test case’s pass / fail criteria for reporting
+      test_criteria: Show commands should be written to config directory.
+      # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
@@ -273,5 +277,3 @@
       show_cmd: null
       expected_output: null
       report_style: modern
-      criteria: {{ global_dut_filter.criteria }}
-      filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -87,8 +87,8 @@
       show_cmd: null
       # Forming expected output in test case file.
       expected_output: null
-      # Setting test case’s pass / fail criteria for reporting
-      test_criteria: Show commands should be written to config directory.
+      # Setting test case’s pass/fail criteria for reporting.
+      test_criteria: Show commands should be executed on device without any error.
       # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -9,10 +9,11 @@ import pytest
 from pyeapi.eapilib import EapiError
 from vane.logger import logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
+from vane import tests_tools, test_case_logger
 
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -38,7 +39,7 @@ class MiscShowCommandTests:
         self.output, output = "", ""
         tops.actual_output, tops.expected_output = {"show_commands": {}}, {"show_commands": {}}
 
-        # Forming output message if test result is passed
+        # Forming output message if the test result is passed
         tops.output_msg = "Show commands are executed on device without any error."
 
         tops.show_cmd = [
@@ -70,11 +71,8 @@ class MiscShowCommandTests:
                         {command: {"command_executed": True}}
                     )
                     output = tops.run_show_cmds([command], encoding="text")
-                    logger.info(
-                        "On device %s, output of %s command is: \n%s\n",
-                        tops.dut_name,
-                        command,
-                        output,
+                    logging.info(
+                        f"On device {tops.dut_name}, output of {command} command is: \n{output}\n"
                     )
                     self.output += f"Output of {command} command is: \n{output}"
                     tops.actual_output["show_commands"].update(
@@ -95,7 +93,7 @@ class MiscShowCommandTests:
                         )
                     else:
                         command_failed_msg += (
-                            f"\nCommand '{command}' execution on the device is failed with the"
+                            f"\nCommand '{command}' execution on the device failed with the"
                             f" following error:\n{error}\n"
                         )
 
@@ -109,8 +107,8 @@ class MiscShowCommandTests:
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
+            logging.error(
+                "On device %s, Error while running the test case is:\n%s",
                 tops.dut_name,
                 tops.actual_output,
             )

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -7,7 +7,6 @@ Testcase for verification of miscellaneous show commands support
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
 from vane.config import dut_objs, test_defs
 from vane import tests_tools, test_case_logger
 

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -95,8 +95,8 @@ class MiscShowCommandTests:
                         )
                     else:
                         command_failed_msg += (
-                            f"\nCommand '{command}' execution on the device is failed with the following"
-                            f" error:\n{error}\n"
+                            f"\nCommand '{command}' execution on the device is failed with the"
+                            f" following error:\n{error}\n"
                         )
 
                         # Updating actual output for a particular command to false when it

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Test cases for verification of misc show commands
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.misc
+class MiscShowCommandTests:
+    """
+    Test cases for verification of misc show commands
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_misc_show_commands"]["duts"]
+    test_ids = dut_parameters["test_misc_show_commands"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_misc_show_commands(self, dut, tests_definitions):
+        """
+        TD: Testcase for verification of misc show commands.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output, output = "", ""
+        tops.actual_output, tops.expected_output = {"misc_show_commands": {}}, {
+            "misc_show_commands": {}
+        }
+
+        # Forming output message if test result is passed
+        tops.output_msg = "Show commands are ran successfully on the device."
+
+        tops.show_cmd = [
+            "show module all",
+            "show logging last 1 days",
+            "show interfaces description",
+            "show interfaces status",
+            "show interfaces | include Ethernet|Port|Vlan|Loopback|Management|MTU",
+            "show lldp neighbors",
+            "show spanning-tree root detail",
+            "show spanning-tree blockedports",
+            "show vlan",
+            "show interfaces trunk",
+            "show vrf",
+            "show ip route vrf all summary",
+        ]
+
+        output_msg = ""
+        try:
+            """
+            TS: Running misc show commands on DUT and verifying show commands are ran successfully
+            on the device.
+            """
+            for command in tops.show_cmd:
+                try:
+                    # Forming expected output as per show commands.
+                    tops.expected_output["misc_show_commands"].update(
+                        {command: {"command_executed": True}}
+                    )
+                    output = tops.run_show_cmds([command], encoding="text")
+                    logger.info(
+                        "On device %s, output of %s command is: \n%s\n",
+                        tops.dut_name,
+                        command,
+                        output,
+                    )
+                    self.output += f"Output of {command} command is: \n{output}"
+                    tops.actual_output["misc_show_commands"].update(
+                        {command: {"command_executed": command in output[0]["command"]}}
+                    )
+
+                except EapiError as error:
+                    tops.output_msg = "\n"
+                    if "Unavailable command" in str(error):
+                        output_msg += (
+                            f"\nCommand '{command}' is not supported on this hardware"
+                            f" platform:\n{error}\n"
+                        )
+
+                        # Updating actual output for a perticular command to false when it
+                        # throws exception
+                        tops.actual_output["misc_show_commands"].update(
+                            {command: {"command_executed": False}}
+                        )
+                tops.output_msg = output_msg
+
+        except (AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_misc_show_commands)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -60,7 +60,7 @@ class MiscShowCommandTests:
 
         try:
             """
-            TS: Running show commands on device and verifying show commands are executed
+            TS: Running show commands on the device and verifying show commands are executed
             successfully on the device.
             """
             for command in tops.show_cmd:
@@ -88,18 +88,18 @@ class MiscShowCommandTests:
                             f" platform:\n{error}\n"
                         )
 
-                        # Updating actual output for a perticular command to false when it
+                        # Updating actual output for a particular command to false when it
                         # throws exception
                         tops.actual_output["show_commands"].update(
                             {command: {"command_executed": False}}
                         )
                     else:
                         command_failed_msg += (
-                            f"\nCommand '{command}' execution on device is failed with following"
+                            f"\nCommand '{command}' execution on the device is failed with the following"
                             f" error:\n{error}\n"
                         )
 
-                        # Updating actual output for a perticular command to false when it
+                        # Updating actual output for a particular command to false when it
                         # throws exception
                         tops.actual_output["show_commands"].update(
                             {command: {"command_executed": False}}

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -107,9 +107,10 @@ class MiscShowCommandTests:
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                "On device %s, Error while running the test case is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+                (
+                    f"On device {tops.dut_name}, Error while running the testcase"
+                    f" is:\n{tops.actual_output}"
+                ),
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_misc_show_commands.py
+++ b/nrfu_tests/test_misc_show_commands.py
@@ -95,7 +95,7 @@ class MiscShowCommandTests:
                         )
                     else:
                         command_failed_msg += (
-                            "\nCommand execution on device is failed with following"
+                            f"\nCommand '{command}' execution on device is failed with following"
                             f" error:\n{error}\n"
                         )
 


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_misc_show_commands.py as per the vane style guide along with that updated following files.
test_definition.yaml: Updated test def with testcase NRFU3.1
test_definition.yaml.j2 : Updated J2 with testcase NRFU3.1

# Any specific logic/part of code you need extra attention on

Verified misc show commands are ran successfully on the device.

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/429


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (nrfu test development)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?

Unit tests and reports :

1) Pass_case : Verified that  misc show commands are executed successfully on the device.

[pass_report.docx](https://github.com/aristanetworks/vane/files/12583401/pass_report.docx)

[pass_with_J2.docx](https://github.com/aristanetworks/vane/files/12497108/pass_with_J2.docx)


2) Fail_case : Verified that test case throws exception when  unavailable 

show commands are not executed successfully on the device.
Reports:

[unavailable_commands.docx](https://github.com/aristanetworks/vane/files/12496497/unavailable_commands.docx)


3) Fail_case : Verified that test case throws exception when one ore more invalid and unavailable show commands are not executed successfully on the device.**Note: Tested with one more show command to test this scenario**
Reports:

[invalid_and_unavailable_command.docx](https://github.com/aristanetworks/vane/files/12513382/invalid_and_unavailable_command.docx)

4) Fail_case : Verified that test case throws exception when invalid commands are not ran successfully on the device.**Note: Tested with one more show command to test this scenario**
Reports:

[invalid_command.docx](https://github.com/aristanetworks/vane/files/12496509/invalid_command.docx)

HTML reports for all mentioned unit testcases:


[misc_show_commands_html_report.zip]

[misc_show_commands_html_report.zip](https://github.com/aristanetworks/vane/files/12583416/misc_show_commands_html_report.zip)

## Bug fix




    
## New feature
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    
# Additional comments
