### PR TITLE
Issue-441:Convert Pytest-CVP Cooling Status test case to Vane #441

### DIFF
--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -216,12 +216,14 @@
       criteria: names
       filter:
         - BLFE1
-    - name: test_
-      description: null
+    - name: test_system_hardware_cooling_status
       test_id: NRFU6.2
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      description: Testcase for the verification of system cooling status.
+      show_cmd: show system environment cooling
+      expected_output:
+        system_cooling_status: coolingOk
+      test_criteria: System cooling status should be 'coolingOk'. # Setting test case’s pass / fail criteria for reporting
+      report_style: modern # Setting report_style as modern If report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -192,11 +192,13 @@
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
-    - name: test_
-      description:
+    - name: test_system_hardware_cooling_status
       test_id: NRFU6.2
-      show_cmd: null
-      expected_output: null
+      description: Testcase for the verification of system cooling status.
+      show_cmd: show system environment cooling
+      expected_output:
+        system_cooling_status: coolingOk
+      test_criteria: System cooling status should be 'coolingOk'.
       report_style: modern
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -2,7 +2,7 @@
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
-Testcase for verification system cooling status.
+Testcase for the verification of system cooling status.
 """
 
 import pytest
@@ -18,7 +18,7 @@ TEST_SUITE = "nrfu_tests"
 @pytest.mark.system
 class SystemHardwareCoolingStatusTests:
     """
-    Testcase for verification system cooling status.
+    Testcase for the verification of system cooling status.
     """
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -28,7 +28,7 @@ class SystemHardwareCoolingStatusTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_system_hardware_cooling_status(self, dut, tests_definitions):
         """
-        TD: Testcase for verification system cooling status.
+        TD: Testcase for the verification of system cooling status.
         Args:
             dut(dict): details related to a particular DUT
             tests_definitions(dict): test suite and test case parameters.
@@ -77,8 +77,8 @@ class SystemHardwareCoolingStatusTests:
 
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = (
-                    "System cooling status is not ok.\nAmbient Temperature"
-                    f" is: {ambient_temperature} C"
+                    "System cooling status is not ok. Ambient Temperature: "
+                    f"{format(ambient_temperature,'.2f')}C')"
                 )
 
         except (AttributeError, LookupError, EapiError) as excep:

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -16,7 +16,7 @@ TEST_SUITE = "nrfu_tests"
 
 @pytest.mark.nrfu_test
 @pytest.mark.system
-class SystemHardwareCoolingStatusTests:
+class SystemCoolingStatusTests:
     """
     Testcase for the verification of system cooling status.
     """
@@ -34,12 +34,11 @@ class SystemHardwareCoolingStatusTests:
             tests_definitions(dict): test suite and test case parameters.
         """
         tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
-        tops.expected_output = {"system_cooling_status": "coolingOk"}
         tops.actual_output = {}
         self.output = ""
 
         # forming output message if test result is passed
-        tops.output_msg = "System cooling status is 'coolingOk' with expected ambient temperature."
+        tops.output_msg = "System cooling status is 'coolingOk'"
 
         try:
             """
@@ -78,7 +77,7 @@ class SystemHardwareCoolingStatusTests:
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = (
                     "System cooling status is not ok. Ambient Temperature: "
-                    f"{format(ambient_temperature,'.2f')}C')"
+                    f"{format(ambient_temperature,'.2f')} C'"
                 )
 
         except (AttributeError, LookupError, EapiError) as excep:

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -7,11 +7,11 @@ Testcase for the verification of system cooling status.
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
+from vane import tests_tools, test_case_logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
@@ -46,10 +46,11 @@ class SystemCoolingStatusTests:
             for device if platform is vEOS.
             """
             version_output = dut["output"]["show version"]["json"]
-            logger.info(
-                "On device %s: Output of 'show version' command is: \n%s\n",
-                tops.dut_name,
-                version_output,
+            logging.info(
+                (
+                    f"On device {tops.dut_name}: Output of 'show version' command is:"
+                    f" \n{version_output}\n"
+                ),
             )
             self.output += f"Output of 'show version' command is: \n{version_output}"
 
@@ -62,11 +63,9 @@ class SystemCoolingStatusTests:
             system status is ok.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
-                "On device %s, output of %s command is:\n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+
+            logging.info(
+                f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n",
             )
 
             self.output += f"Output of {tops.show_cmd} command is: \n{output}"
@@ -82,10 +81,11 @@ class SystemCoolingStatusTests:
 
         except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+            logging.error(
+                (
+                    f"On device {tops.dut_name}, Error while running the testcase"
+                    f" is:\n{tops.actual_output}"
+                ),
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -34,16 +34,16 @@ class SystemHardwareCoolingStatusTests:
             tests_definitions(dict): test suite and test case parameters.
         """
         tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
-        tops.expected_output = {}
+        tops.expected_output = {"system_cooling_status": "coolingOk"}
         tops.actual_output = {}
         self.output = ""
 
         # forming output message if test result is passed
-        tops.output_msg = "System cooling status is ok."
+        tops.output_msg = "System cooling status is 'coolingOk' with expected ambient temperature."
 
         try:
             """
-            TS: Running 'show version' command on device and Skipping the test case
+            TS: Running `show version` command on device and skipping the test case
             for device if platform is vEOS.
             """
             version_output = dut["output"]["show version"]["json"]
@@ -52,11 +52,11 @@ class SystemHardwareCoolingStatusTests:
                 tops.dut_name,
                 version_output,
             )
-            self.output += f"\n\nOutput of 'show version' command is: \n{version_output}"
+            self.output += f"Output of 'show version' command is: \n{version_output}"
 
             # Skipping testcase if device is vEOS.
             if "vEOS" in version_output.get("modelName"):
-                pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
+                pytest.skip(f"{tops.dut_name} is vEOS device, hence test is skipped.")
 
             """
             TS: Running `show system environment cooling` command and verifying
@@ -74,15 +74,14 @@ class SystemHardwareCoolingStatusTests:
             system_cooling_status = output.get("systemStatus")
             ambient_temperature = output.get("ambientTemperature")
             tops.actual_output.update({"system_cooling_status": system_cooling_status})
-            tops.expected_output.update({"system_cooling_status": "coolingOk"})
 
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = (
-                    f"System cooling status is not ok.\nAmbient Temperature"
+                    "System cooling status is not ok.\nAmbient Temperature"
                     f" is: {ambient_temperature} C"
                 )
 
-        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+        except (AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logger.error(
                 "On device %s, Error while running the testcase is:\n%s",

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Testcase for verification system cooling status.
+"""
+
+import pytest
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.system
+class SystemHardwareCoolingStatusTests:
+    """
+    Testcase for verification system cooling status.
+    """
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_system_hardware_cooling_status"]["duts"]
+    test_ids = dut_parameters["test_system_hardware_cooling_status"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_system_hardware_cooling_status(self, dut, tests_definitions):
+        """
+        TD: Testcase for verification system cooling status.
+        Args:
+            dut(dict): details related to a particular DUT
+            tests_definitions(dict): test suite and test case parameters.
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        tops.expected_output = {}
+        tops.actual_output = {}
+        self.output = ""
+
+        # forming output message if test result is passed
+        tops.output_msg = "System cooling status is ok."
+
+        try:
+            """
+            TS: Running 'show version' command on device and Skipping the test case
+            for device if platform is vEOS.
+            """
+            version_output = dut["output"]["show version"]["json"]
+            logger.info(
+                "On device %s: Output of 'show version' command is: \n%s\n",
+                tops.dut_name,
+                version_output,
+            )
+            self.output += f"\n\nOutput of 'show version' command is: \n{version_output}"
+
+            # Skipping testcase if device is vEOS.
+            if "vEOS" in version_output.get("modelName"):
+                pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
+
+            """
+            TS: Running `show system environment cooling` command and verifying
+            system status is ok.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is:\n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+
+            self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
+            system_cooling_status = output.get("systemStatus")
+            ambient_temperature = output.get("ambientTemperature")
+            tops.actual_output.update({"system_cooling_status": system_cooling_status})
+            tops.expected_output.update({"system_cooling_status": "coolingOk"})
+
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = (
+                    f"System cooling status is not ok.\nAmbient Temperature"
+                    f" is: {ambient_temperature} C"
+                )
+
+        except (AssertionError, AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_system_hardware_cooling_status)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_system_hardware_cooling_status.py
+++ b/nrfu_tests/test_system_hardware_cooling_status.py
@@ -70,7 +70,7 @@ class SystemHardwareCoolingStatusTests:
                 output,
             )
 
-            self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
+            self.output += f"Output of {tops.show_cmd} command is: \n{output}"
             system_cooling_status = output.get("systemStatus")
             ambient_temperature = output.get("ambientTemperature")
             tops.actual_output.update({"system_cooling_status": system_cooling_status})


### PR DESCRIPTION
# Please include a summary of the changes

Converted test_system_hardware_cooling_status.py  as per the vane style guide along with that updated following files.
Use Test ID: NRFU6.2
test_definition.yaml: Updated test def with testcase  NRFU6.2
test_definition.yaml.j2: Updated J2 with testcase  NRFU6.2
pytest.ini: Added marker nrfu_test and system
nrfu_tests/nrfu_tests/test_system_hardware_cooling_status.py: Added testcase for NRFU6.2
masterdef.yaml: Updated master def file with global filter.
Test case should be skipped if vEOS : Added condition in test case.

# Any specific logic/part of code you need extra attention on

This testcase will verify the System cooling status should be 'coolingOk' in 'show system environment cooling' command output. If cooling status is not found test case will fail.

# Include the Issue number and link
#441 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU Testcase)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Unit Tests:

- Tested for all the verifying that the system status is ok..: Passed

[PASS-441.docx](https://github.com/aristanetworks/vane/files/12610068/PASS-441.docx)


- Tested if system status is not ok.: Failed. (with hardcoded output)
 
[441-FAIL-REPORT.docx](https://github.com/aristanetworks/vane/files/12606008/441-FAIL-REPORT.docx)



- Verified system status is ok: passed (With generate test definition True and J2 True )

[PASS-441-WITH-J2.docx](https://github.com/aristanetworks/vane/files/12610080/PASS-441-WITH-J2.docx)


   
- Test case skipped if device platform is vEOS.

[441-SKIP-REPORT.docx](https://github.com/aristanetworks/vane/files/12605997/441-SKIP-REPORT.docx)




- HTML reports:


[441-REPORT-HTML.zip](https://github.com/aristanetworks/vane/files/12610114/441-REPORT-HTML.zip)




## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
