### PR TITLE
Issue-419: Convert Pytest-CVP DNS test case to Vane

### DIFF
--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -3,6 +3,10 @@
   # filter:
   #   - BLFE1
 testcase_data:
+  NRFU1.1:
+    dns_name_server_check: # If you want the test case to fail when a name-server is not configured on the device, change these parameters to True for the IP version you need.
+      ipv4_fail_if_not_configured: True
+      ipv6_fail_if_not_configured: False
   NRFU2.1:
     descriptions_to_ignore: # Interfaces to ignore the following descriptions
       - unused

--- a/nrfu_tests/test_base_services_dns.py
+++ b/nrfu_tests/test_base_services_dns.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Arista Networks, Inc. Confidential and Proprietary.
+
+"""
+Testcases for verification of DNS base services.
+"""
+
+import pytest
+import pyeapi.eapilib
+from pyeapi.eapilib import EapiError
+from vane.logger import logger
+from vane.config import dut_objs, test_defs
+from vane import tests_tools
+
+TEST_SUITE = "nrfu_tests"
+
+
+@pytest.mark.nrfu_test
+@pytest.mark.base_services
+class DnsBaseServicesTests:
+    """
+    Testcases for verification of DNS base services.
+    """
+
+    def verify_dns(self, vx_name_servers, ip_version, ipvx_fail_if_not_configured, dut, tops):
+        """
+        Utility function for the verification of DNS functionality.
+        Args:
+            vx_name_servers(String): IP address of the name server.
+            ipvx_fail_if_not_configured(boolean):
+            dut(dict): details related to a particular device
+            tops(dict): Testops class object
+        Returns:
+            dict: Actual output for verification
+        """
+        ip_version = ip_version.split("_")[0]
+        actual_output = {}
+
+        try:
+            if ipvx_fail_if_not_configured:
+                assert (
+                    vx_name_servers
+                ), f"For {ip_version}, name-server is not configured on device{dut['name']}.\n"
+
+            reverse_resolution_ip = vx_name_servers[0]
+            bash_cmd = f"bash timeout 10 nslookup {reverse_resolution_ip}"
+            output = tops.run_show_cmds([bash_cmd])
+            logger.info(
+                "On device %s, output of %s command is: \n%s\n",
+                tops.dut_name,
+                bash_cmd,
+                output,
+            )
+            actual_output = {"dns_request_successful": True}
+
+        except (AssertionError, pyeapi.eapilib.CommandError):
+            actual_output = {"dns_request_successful": False}
+
+        return actual_output
+
+    dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
+    test_duts = dut_parameters["test_dns_base_services"]["duts"]
+    test_ids = dut_parameters["test_dns_base_services"]["ids"]
+
+    @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
+    def test_dns_base_services(self, dut, tests_definitions):
+        """
+        TD: Testcase for verification of DNS base services.
+        Args:
+            dut(dict): details related to a particular device.
+            tests_definitions(dict): test suite and test case parameters.
+        """
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+        self.output = ""
+        test_params = tops.test_parameters["dns_name_server_check"]
+        tops.actual_output = {}
+
+        # Forming output message if test result is passed
+        tops.output_msg = "IPv4 and IPv6 name servers are configured on the device."
+
+        try:
+            """
+            TS: Running 'show ip name-server' command on the device and verifying the
+            DNS resolution by doing a reverse lookup for the IP of the first server configured.
+            """
+            output = dut["output"][tops.show_cmd]["json"]
+            logger.info(
+                "On device %s, output of %s command is: \n%s\n",
+                tops.dut_name,
+                tops.show_cmd,
+                output,
+            )
+            self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
+
+            # Skipping testcase if SSO protocol is not configured on the device.
+            if not output.get("nameServerConfigs"):
+                pytest.skip(
+                    f"Name server is not configured on {tops.dut_name}, hence skipping the"
+                    " testcase."
+                )
+
+            # Separating out v4 and v6 name servers
+            v4_name_servers = output["v4NameServers"]
+            v6_name_servers = output["v6NameServers"]
+
+            tops.actual_output.update(
+                {
+                    "ipv4_name_server_details": self.verify_dns(
+                        v4_name_servers,
+                        list(test_params.keys())[0],
+                        test_params["ipv4_fail_if_not_configured"],
+                        dut,
+                        tops,
+                    )
+                }
+            )
+
+            tops.actual_output.update(
+                {
+                    "ipv6_name_server_details": self.verify_dns(
+                        v6_name_servers,
+                        list(test_params.keys())[1],
+                        test_params["ipv4_fail_if_not_configured"],
+                        dut,
+                        tops,
+                    )
+                }
+            )
+
+            # Forming the output message if the testcase is failed
+            if tops.actual_output != tops.expected_output:
+                tops.output_msg = "\n"
+                for name_server, server_details in tops.actual_output.items():
+                    ip_version = name_server.split("_")[0]
+                    if not server_details["dns_request_successful"]:
+                        tops.output_msg += (
+                            f"DNS request is not successful for {ip_version} version.\n"
+                        )
+
+        except (AttributeError, LookupError, EapiError) as excep:
+            tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
+            logger.error(
+                "On device %s, Error while running the testcase is:\n%s",
+                tops.dut_name,
+                tops.actual_output,
+            )
+
+        tops.test_result = tops.expected_output == tops.actual_output
+        tops.parse_test_steps(self.test_dns_base_services)
+        tops.generate_report(tops.dut_name, self.output)
+        assert tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_base_services_dns.py
+++ b/nrfu_tests/test_base_services_dns.py
@@ -22,42 +22,6 @@ class DnsBaseServicesTests:
     Testcases for verification of DNS base services.
     """
 
-    def verify_dns(self, vx_name_servers, ip_version, ipvx_fail_if_not_configured, dut, tops):
-        """
-        Utility function for the verification of DNS functionality.
-        Args:
-            vx_name_servers(String): IP address of the name server.
-            ipvx_fail_if_not_configured(boolean):
-            dut(dict): details related to a particular device
-            tops(dict): Testops class object
-        Returns:
-            dict: Actual output for verification
-        """
-        ip_version = ip_version.split("_")[0]
-        actual_output = {}
-
-        try:
-            if ipvx_fail_if_not_configured:
-                assert (
-                    vx_name_servers
-                ), f"For {ip_version}, name-server is not configured on device{dut['name']}.\n"
-
-            reverse_resolution_ip = vx_name_servers[0]
-            bash_cmd = f"bash timeout 10 nslookup {reverse_resolution_ip}"
-            output = tops.run_show_cmds([bash_cmd])
-            logger.info(
-                "On device %s, output of %s command is: \n%s\n",
-                tops.dut_name,
-                bash_cmd,
-                output,
-            )
-            actual_output = {"dns_request_successful": True}
-
-        except (AssertionError, pyeapi.eapilib.CommandError):
-            actual_output = {"dns_request_successful": False}
-
-        return actual_output
-
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
     test_duts = dut_parameters["test_dns_base_services"]["duts"]
     test_ids = dut_parameters["test_dns_base_services"]["ids"]
@@ -74,6 +38,7 @@ class DnsBaseServicesTests:
         self.output = ""
         test_params = tops.test_parameters["dns_name_server_check"]
         tops.actual_output = {}
+        tops.expected_output = {}
 
         # Forming output message if test result is passed
         tops.output_msg = "IPv4 and IPv6 name servers are configured on the device."
@@ -93,46 +58,42 @@ class DnsBaseServicesTests:
             self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
 
             # Skipping testcase if SSO protocol is not configured on the device.
-            if not output.get("nameServerConfigs"):
+            version_verification = [element for element in [test_params.values()] if bool(element)]
+            if all(list(version_verification)[0]):
                 pytest.skip(
                     f"Name server is not configured on {tops.dut_name}, hence skipping the"
                     " testcase."
                 )
 
-            # Separating out v4 and v6 name servers
-            v4_name_servers = output["v4NameServers"]
-            v6_name_servers = output["v6NameServers"]
-
-            tops.actual_output.update(
-                {
-                    "ipv4_name_server_details": self.verify_dns(
-                        v4_name_servers,
-                        list(test_params.keys())[0],
-                        test_params["ipv4_fail_if_not_configured"],
-                        dut,
-                        tops,
+            try:
+                for ip_version_verification, verification_status in test_params.items():
+                    if verification_status and "ipv4" in ip_version_verification:
+                        ip_version = ip_version_verification.split("_")[0]
+                        vx_name_servers = output["v4NameServers"]
+                    elif verification_status and "ipv6" in ip_version_verification:
+                        ip_version = ip_version_verification.split("_")[0]
+                        vx_name_servers = output["v6NameServers"]
+                    tops.expected_output.update({f"{ip_version}_dns_request_successful": True})
+                    reverse_resolution_ip = vx_name_servers[0]
+                    bash_cmd = f"bash timeout 10 nslookup {reverse_resolution_ip}"
+                    bash_cmd_output = tops.run_show_cmds([bash_cmd])
+                    logger.info(
+                        "On device %s, output of %s command is: \n%s\n",
+                        tops.dut_name,
+                        bash_cmd,
+                        bash_cmd_output,
                     )
-                }
-            )
+                    tops.actual_output.update({f"{ip_version}_dns_request_successful": True})
 
-            tops.actual_output.update(
-                {
-                    "ipv6_name_server_details": self.verify_dns(
-                        v6_name_servers,
-                        list(test_params.keys())[1],
-                        test_params["ipv4_fail_if_not_configured"],
-                        dut,
-                        tops,
-                    )
-                }
-            )
+            except pyeapi.eapilib.CommandError:
+                tops.actual_output.update({f"{ip_version}_dns_request_successful": False})
 
             # Forming the output message if the testcase is failed
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = "\n"
-                for name_server, server_details in tops.actual_output.items():
-                    ip_version = name_server.split("_")[0]
-                    if not server_details["dns_request_successful"]:
+                for name_server_details, dns_status in tops.actual_output.items():
+                    ip_version = name_server_details.split("_")[0]
+                    if not dns_status:
                         tops.output_msg += (
                             f"DNS request is not successful for {ip_version} version.\n"
                         )

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -1,13 +1,13 @@
 - name: nrfu_tests
   testcases:
     - name: test_dns_base_services
-      description: Testcase for verification of DNS resolution functionality.
+      description: Test case for the verification of DNS resolution functionality.
       test_id: NRFU1.1
       show_cmd: show ip name-server
-      expected_output: null # Forming the expected output dynamically in the testcase file.
+      expected_output: null # Forming the expected output dynamically in the test case file.
       test_criteria: Reverse name server lookup should be successful for name servers configured on the device. # Setting test case pass/fail criteria for reporting
-      report_style: modern # Setting report_style as modern. If report type is set as modern then it will update steps, assumptions, external systems in docx report
-      dns_name_server_check: # If you want test case to fail when a name-server is not configured on device, change these parameters to True for the IP version you need.
+      report_style: modern # Setting report_style as modern. If the report type is set as modern then it will update steps, assumptions and external systems in docx report
+      dns_name_server_check: # If you want the test case to fail when a name-server is not configured on the device, change these parameters to True for the IP version you need.
         ipv4_fail_if_not_configured: True
         ipv6_fail_if_not_configured: False
       criteria: names

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -1,11 +1,15 @@
 - name: nrfu_tests
   testcases:
-    - name: test_
-      description: null
+    - name: test_dns_base_services
+      description: Testcase for verification of DNS resolution functionality.
       test_id: NRFU1.1
-      show_cmd: null
-      expected_output: null
-      report_style: modern
+      show_cmd: show ip name-server
+      expected_output: null # Forming the expected output dynamically in the testcase file.
+      test_criteria: Reverse name server lookup should be successful for name servers configured on the device. # Setting test case pass/fail criteria for reporting
+      report_style: modern # Setting report_style as modern. If report type is set as modern then it will update steps, assumptions, external systems in docx report
+      dns_name_server_check: # If you want test case to fail when a name-server is not configured on device, change these parameters to True for the IP version you need.
+        ipv4_fail_if_not_configured: True
+        ipv6_fail_if_not_configured: False
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -1,11 +1,16 @@
 - name: nrfu_tests
   testcases:
-    - name: test_
-      description:
+    - name: test_dns_base_services
+      description: Testcase for verification of DNS resolution by doing a reverse lookup for the IP of the first server configured.
       test_id: NRFU1.1
-      show_cmd: null
+      {% set test_data = testcase_data["NRFU1.1"].dns_name_server_check %}
+      show_cmd: show ip name-server
       expected_output: null
+      test_criteria: Reverse name server lookup should be successful for name servers configured on the device.
       report_style: modern
+      dns_name_server_check:
+        ipv4_fail_if_not_configured: {{ test_data.ipv4_fail_if_not_configured }}
+        ipv6_fail_if_not_configured: {{ test_data.ipv6_fail_if_not_configured }}
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_ntp_clocks

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -1,7 +1,7 @@
 - name: nrfu_tests
   testcases:
     - name: test_dns_base_services
-      description: Testcase for verification of DNS resolution by doing a reverse lookup for the IP of the first server configured.
+      description: Test case for the verification of DNS resolution functionality.
       test_id: NRFU1.1
       {% set test_data = testcase_data["NRFU1.1"].dns_name_server_check %}
       show_cmd: show ip name-server

--- a/nrfu_tests/test_dns_base_services.py
+++ b/nrfu_tests/test_dns_base_services.py
@@ -7,8 +7,9 @@ Test case for verification of DNS base services.
 
 import pytest
 from pyeapi.eapilib import EapiError
+from vane import test_case_logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools, test_case_logger
+from vane import tests_tools
 
 TEST_SUITE = "nrfu_tests"
 logging = test_case_logger.setup_logger(__file__)

--- a/nrfu_tests/test_dns_base_services.py
+++ b/nrfu_tests/test_dns_base_services.py
@@ -51,10 +51,10 @@ class DnsBaseServicesTests:
             """
             output = dut["output"][tops.show_cmd]["json"]
             logging.info(
-                "On device %s, output of %s command is: \n%s\n",
-                tops.dut_name,
-                tops.show_cmd,
-                output,
+                (
+                    f"On device {tops.dut_name}, the output of the `{tops.show_cmd}` command"
+                    f" is: \n{output}\n"
+                ),
             )
             self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
 
@@ -92,10 +92,10 @@ class DnsBaseServicesTests:
                         bash_cmd = f"bash timeout 10 nslookup {reverse_resolution_ip}"
                         bash_cmd_output = tops.run_show_cmds([bash_cmd])
                         logging.info(
-                            "On device %s, output of %s command is: \n%s\n",
-                            tops.dut_name,
-                            bash_cmd,
-                            bash_cmd_output,
+                            (
+                                f"On device {tops.dut_name}, the output of the `{bash_cmd}` command"
+                                f" is: \n{bash_cmd_output}\n"
+                            ),
                         )
                         tops.actual_output["name_servers"].update(
                             {
@@ -124,9 +124,8 @@ class DnsBaseServicesTests:
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
-                "On device %s, Error while running the test case is:\n%s",
-                tops.dut_name,
-                tops.actual_output,
+                f"On device {tops.dut_name}, Error while running the test case"
+                f" is:\n{tops.actual_output}"
             )
 
         tops.test_result = tops.expected_output == tops.actual_output

--- a/nrfu_tests/test_dns_base_services.py
+++ b/nrfu_tests/test_dns_base_services.py
@@ -6,7 +6,6 @@ Testcases for verification of DNS base services.
 """
 
 import pytest
-import pyeapi.eapilib
 from pyeapi.eapilib import EapiError
 from vane.logger import logger
 from vane.config import dut_objs, test_defs
@@ -45,7 +44,7 @@ class DnsBaseServicesTests:
 
         try:
             """
-            TS: Running 'show ip name-server' command on the device and verifying the
+            TS: Running `show ip name-server` command on the device and verifying the
             DNS resolution by doing a reverse lookup for the IP of the first server configured.
             """
             output = dut["output"][tops.show_cmd]["json"]
@@ -85,7 +84,7 @@ class DnsBaseServicesTests:
                     )
                     tops.actual_output.update({f"{ip_version}_dns_request_successful": True})
 
-            except pyeapi.eapilib.CommandError:
+            except EapiError:
                 tops.actual_output.update({f"{ip_version}_dns_request_successful": False})
 
             # Forming the output message if the testcase is failed

--- a/nrfu_tests/test_dns_base_services.py
+++ b/nrfu_tests/test_dns_base_services.py
@@ -2,23 +2,23 @@
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
-Testcases for verification of DNS base services.
+Test case for verification of DNS base services.
 """
 
 import pytest
 from pyeapi.eapilib import EapiError
-from vane.logger import logger
 from vane.config import dut_objs, test_defs
-from vane import tests_tools
+from vane import tests_tools, test_case_logger
 
 TEST_SUITE = "nrfu_tests"
+logging = test_case_logger.setup_logger(__file__)
 
 
 @pytest.mark.nrfu_test
 @pytest.mark.base_services
 class DnsBaseServicesTests:
     """
-    Testcases for verification of DNS base services.
+    Test case for verification of DNS base services.
     """
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -28,7 +28,7 @@ class DnsBaseServicesTests:
     @pytest.mark.parametrize("dut", test_duts, ids=test_ids)
     def test_dns_base_services(self, dut, tests_definitions):
         """
-        TD: Testcase for verification of DNS resolution functionality.
+        TD: Test case for verification of DNS resolution functionality.
         Args:
             dut(dict): details related to a particular device.
             tests_definitions(dict): test suite and test case parameters.
@@ -39,7 +39,7 @@ class DnsBaseServicesTests:
         tops.actual_output = {"name_servers": {}}
         tops.expected_output = {"name_servers": {}}
 
-        # Forming output message if test result is passed
+        # Forming output message if the test result is passed
         tops.output_msg = (
             "Reverse name server lookup is successful for name servers configured on the device."
         )
@@ -50,7 +50,7 @@ class DnsBaseServicesTests:
             DNS resolution by doing a reverse lookup for the IP of the first server configured.
             """
             output = dut["output"][tops.show_cmd]["json"]
-            logger.info(
+            logging.info(
                 "On device %s, output of %s command is: \n%s\n",
                 tops.dut_name,
                 tops.show_cmd,
@@ -58,12 +58,12 @@ class DnsBaseServicesTests:
             )
             self.output += f"\n\nOutput of {tops.show_cmd} command is: \n{output}"
 
-            # Skipping testcase if name servers are not configured on the device.
+            # Skipping test case if name servers are not configured on the device.
             version_verification = list(test_params.values())
             if not any(version_verification):
                 pytest.skip(
                     f"Name servers are not configured on {tops.dut_name}, hence skipping the"
-                    " testcase."
+                    " test case."
                 )
 
             try:
@@ -91,7 +91,7 @@ class DnsBaseServicesTests:
 
                         bash_cmd = f"bash timeout 10 nslookup {reverse_resolution_ip}"
                         bash_cmd_output = tops.run_show_cmds([bash_cmd])
-                        logger.info(
+                        logging.info(
                             "On device %s, output of %s command is: \n%s\n",
                             tops.dut_name,
                             bash_cmd,
@@ -110,7 +110,7 @@ class DnsBaseServicesTests:
                     {ip_version: {reverse_resolution_ip: {"reverse_nslookup_successful": False}}}
                 )
 
-            # Forming the output message if the testcase is failed
+            # Forming the output message if the test case failed
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = "\n"
                 for version_status in tops.actual_output["name_servers"].values():
@@ -123,8 +123,8 @@ class DnsBaseServicesTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
-            logger.error(
-                "On device %s, Error while running the testcase is:\n%s",
+            logging.error(
+                "On device %s, Error while running the test case is:\n%s",
                 tops.dut_name,
                 tops.actual_output,
             )


### PR DESCRIPTION
# Please include a summary of the changes

* test_definition.yaml: Updated test def with testcase NRFU1.1
* test_definition.yaml.j2: Updated J2 with testcase NRFU1.1
* nrfu_tests/nrfu_tests/test_base_services_dns.py: Added testcase for NRFU1.1
* masterdef.yaml: Updated master def file with global filter and testcase data

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on

# Include the Issue number and link
#419 

Make sure to link the issue in the github PR UI 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (NRFU Testcase)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Unit Testing:

1. Tested the testcase for pass scenario where DNS is reachable:
    [report_2309061815.docx](https://github.com/aristanetworks/vane/files/12539413/report_2309061815.docx)
    [Pass Reports DNS.zip](https://github.com/aristanetworks/vane/files/12539421/Pass.Reports.DNS.zip)

2. Tested the testcase for fail scenario where the DNS is not successful.
    [report_2309061821.docx](https://github.com/aristanetworks/vane/files/12539423/report_2309061821.docx)
    [Fail DNS.zip](https://github.com/aristanetworks/vane/files/12539427/Fail.DNS.zip)

3. Tested the testcase for pass scenario using J2 File.
    [report_2309061825.docx](https://github.com/aristanetworks/vane/files/12539430/report_2309061825.docx)
    [Pass using J2.zip](https://github.com/aristanetworks/vane/files/12539433/Pass.using.J2.zip)

4. Tested the testcase for skipped scenario if the name servers are not configured.
    [report_2309061827.docx](https://github.com/aristanetworks/vane/files/12539438/report_2309061827.docx)
    [Skipped.zip](https://github.com/aristanetworks/vane/files/12539440/Skipped.zip)

5. Tested the assertion scenario for the testcase if the name server details are not found.
    [report_2309061819.docx](https://github.com/aristanetworks/vane/files/12539456/report_2309061819.docx)
    [Assertion.zip](https://github.com/aristanetworks/vane/files/12539462/Assertion.zip)

6. Tested the testcase after the conflict resolution for pass scenario.
    Using test definition file:
    [report_2309291500.docx](https://github.com/aristanetworks/vane/files/12763442/report_2309291500.docx)
    [DNS Pass using test def.zip](https://github.com/aristanetworks/vane/files/12763446/DNS.Pass.using.test.def.zip)

    Using J2:
    [report_2309291502.docx](https://github.com/aristanetworks/vane/files/12763569/report_2309291502.docx)
    [DNS pass using J2.zip](https://github.com/aristanetworks/vane/files/12763577/DNS.pass.using.J2.zip)

7. Tested the testcase after updating the logger in the testcase.
    [DNS Pass.zip](https://github.com/aristanetworks/vane/files/12608132/DNS.Pass.zip)
    [report_2309141649.docx](https://github.com/aristanetworks/vane/files/12608134/report_2309141649.docx)


## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
