### PR TITLE
Added test id to html report

### DIFF
--- a/nrfu_tests/conftest.py
+++ b/nrfu_tests/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2019, Arista Networks EOS+
+# Copyright (c) 2023, Arista Networks EOS+
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,13 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# pylint: disable=import-error,no-name-in-module,invalid-name
+# pylint: disable=invalid-name
 
 """ Alter behavior of PyTest """
 
-import re
 import pytest
-from py.xml import html
 
 pytest_plugins = "vane.fixtures"
 
@@ -67,62 +65,3 @@ def definitions(request):
 
     cli_arg = request.config.getoption("--definitions")
     return cli_arg
-
-
-def find_nodeid(nodeid):
-    """Return device parameter
-
-    Args:
-        nodeid (str): Device Name
-
-    Return: Name of device
-
-    """
-
-    if re.match(r".*\[(.*)\]", nodeid):
-        return re.match(r".*\[(.*)\]", nodeid)[1]
-
-    return "NONE"
-
-
-def pytest_html_results_table_header(cells):
-    """Create custom PyTest-HTML Header Row
-
-    Args:
-        cells: Cell data
-    """
-
-    cells.insert(2, html.th("Description"))
-    cells.insert(1, html.th("Device", class_="sortable string", col="device"))
-    cells.pop()
-
-
-def pytest_html_results_table_row(report, cells):
-    """Create custom PyTest-HTML report row
-
-    Args:
-        report: pytest report
-        cells: Cell data
-    """
-
-    cells.insert(2, html.td(getattr(report, "description", "")))
-    cells.insert(1, html.td(find_nodeid(report.nodeid), class_="col-device"))
-    cells.pop()
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item):
-    """Called to create a _pytest.reports.TestReport for each of the setup,
-    call and teardown runtest phases of a test item.
-
-    """
-
-    outcome = yield
-    report = outcome.get_result()
-
-    if str(item.function.__doc__).split("Args:", maxsplit=1)[0]:
-        report.description = str(item.function.__doc__).split("Args:", maxsplit=1)[0]
-    elif str(item.function.__doc__):
-        report.description = str(item.function.__doc__)
-    else:
-        report.description = "No Description"

--- a/sample_network_tests/conftest.py
+++ b/sample_network_tests/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2019, Arista Networks EOS+
+# Copyright (c) 2023, Arista Networks EOS+
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,14 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# pylint: disable=import-error,no-name-in-module,invalid-name
+# pylint: disable=invalid-name
 
 """ Alter behavior of PyTest """
 
-import re
 import pytest
-from py.xml import html
-from vane.config import test_defs
 
 pytest_plugins = "vane.fixtures"
 
@@ -68,88 +65,3 @@ def definitions(request):
 
     cli_arg = request.config.getoption("--definitions")
     return cli_arg
-
-
-def find_nodeid(nodeid):
-    """Return device parameter
-
-    Args:
-        nodeid (str): Device Name
-
-    Return: Name of device
-
-    """
-
-    if re.match(r".*\[(.*)\]", nodeid):
-        return re.match(r".*\[(.*)\]", nodeid)[1]
-
-    return "NONE"
-
-
-def read_test_id(report):
-    """Returns test id for the test case being executed
-
-    Args:
-        report: pytest report
-    """
-    last_double_colon_index = report.nodeid.rfind("::")
-    last_open_bracket_index = report.nodeid.rfind("[")
-    test_case_name = report.nodeid[
-        last_double_colon_index + 2 : last_open_bracket_index  # noqa: E203
-    ]
-
-    for test_suite in test_defs["test_suites"]:
-        for test_case in test_suite["testcases"]:
-            if test_case_name == test_case["name"]:
-                if "test_id" in test_case:
-                    return test_case["test_id"]
-                return ""
-
-    return ""
-
-
-def pytest_html_results_table_header(cells):
-    """Create custom PyTest-HTML Header Row
-
-    Args:
-        cells: Cell data
-    """
-
-    cells.insert(2, html.th("Description"))
-    cells.insert(1, html.th("Test ID"))
-    cells.insert(1, html.th("Device", class_="sortable string", col="device"))
-    cells.pop()
-
-
-def pytest_html_results_table_row(report, cells):
-    """Create custom PyTest-HTML report row
-
-    Args:
-        report: pytest report
-        cells: Cell data
-    """
-
-    cells.insert(2, html.td(getattr(report, "description", "")))
-    cells.insert(1, html.td(getattr(report, "test_id", "")))
-    cells.insert(1, html.td(find_nodeid(report.nodeid), class_="col-device"))
-    cells.pop()
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item):
-    """Called to create a _pytest.reports.TestReport for each of the setup,
-    call and teardown runtest phases of a test item.
-
-    """
-
-    outcome = yield
-    report = outcome.get_result()
-
-    report.test_id = read_test_id(report)
-
-    if str(item.function.__doc__).split("Args:", maxsplit=1)[0]:
-        report.description = str(item.function.__doc__).split("Args:", maxsplit=1)[0]
-    elif str(item.function.__doc__):
-        report.description = str(item.function.__doc__)
-    else:
-        report.description = "No Description"

--- a/vane/fixtures.py
+++ b/vane/fixtures.py
@@ -31,15 +31,17 @@
 
 # Ignore redefined-outer-name since the dut/duts methods are defined as fixtures
 # and are passed as parameters to other methods in this module
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,import-error,no-name-in-module
 
 """
 Fixture setup and teardown functions
 """
 
 import datetime
+import re
 import pytest
 
+from py.xml import html
 from jinja2 import Template
 from vane import tests_tools
 from vane.config import dut_objs, test_defs
@@ -320,3 +322,88 @@ def setup_testcase(request, duts):
 
     yield
     perform_teardown(duts, checkpoint, setup_config)
+
+
+def find_nodeid(nodeid):
+    """Return device parameter
+
+    Args:
+        nodeid (str): Device Name
+
+    Return: Name of device
+
+    """
+
+    if re.match(r".*\[(.*)\]", nodeid):
+        return re.match(r".*\[(.*)\]", nodeid)[1]
+
+    return "NONE"
+
+
+def read_test_id(report):
+    """Returns test id for the test case being executed
+
+    Args:
+        report: pytest report
+    """
+    last_double_colon_index = report.nodeid.rfind("::")
+    last_open_bracket_index = report.nodeid.rfind("[")
+    test_case_name = report.nodeid[
+        last_double_colon_index + 2 : last_open_bracket_index  # noqa: E203
+    ]
+
+    for test_suite in test_defs["test_suites"]:
+        for test_case in test_suite["testcases"]:
+            if test_case_name == test_case["name"]:
+                if "test_id" in test_case:
+                    return test_case["test_id"]
+                return ""
+
+    return ""
+
+
+def pytest_html_results_table_header(cells):
+    """Create custom PyTest-HTML Header Row
+
+    Args:
+        cells: Cell data
+    """
+
+    cells.insert(2, html.th("Description"))
+    cells.insert(1, html.th("Test ID"))
+    cells.insert(1, html.th("Device", class_="sortable string", col="device"))
+    cells.pop()
+
+
+def pytest_html_results_table_row(report, cells):
+    """Create custom PyTest-HTML report row
+
+    Args:
+        report: pytest report
+        cells: Cell data
+    """
+
+    cells.insert(2, html.td(getattr(report, "description", "")))
+    cells.insert(1, html.td(getattr(report, "test_id", "")))
+    cells.insert(1, html.td(find_nodeid(report.nodeid), class_="col-device"))
+    cells.pop()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item):
+    """Called to create a _pytest.reports.TestReport for each of the setup,
+    call and teardown runtest phases of a test item.
+
+    """
+
+    outcome = yield
+    report = outcome.get_result()
+
+    report.test_id = read_test_id(report)
+
+    if str(item.function.__doc__).split("Args:", maxsplit=1)[0]:
+        report.description = str(item.function.__doc__).split("Args:", maxsplit=1)[0]
+    elif str(item.function.__doc__):
+        report.description = str(item.function.__doc__)
+    else:
+        report.description = "No Description"


### PR DESCRIPTION
# Please include a summary of the changes

* sample_network_tests/conftest.py: Removed html customization logic to fixtures.py (within vane framework)
* nrfu_tests/conftest.py: Removed html customization logic to fixtures.py (within vane framework)
* fixtures.py : added report customisation logic along with newer logic to add column for test id"


# Any specific logic/part of code you need extra attention on

New function: Retrieving test id from test defs: https://github.com/aristanetworks/vane/blob/d8dec32012ba6dd5e76e5f411ffef9be48cbc385/vane/fixtures.py#L343

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/349

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
    
## New feature

    Manually: Can see the added columns
     
<img width="1719" alt="Screenshot 2023-09-21 at 12 12 53 PM" src="https://github.com/aristanetworks/vane/assets/123415500/f8dd999f-d0a3-4536-9317-c45e8ef5e7a7">

    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
 
    
# Additional comments

We have a conftest.py file for each test directory, I have changed the one in sample_network tests, the ones for other test directories will also have to be changed if we want this change in those directories as well

UPDATE: this comment is now addressed since we added this to fixtures.py which is imported as plugin in all test directories
