### PR TITLE
Issue #526: Check if cmds have 'show clock' as first cmd

### DIFF
--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1386,8 +1386,13 @@ class TestOps:
 
         self.set_evidence_default(dut_name)
 
+        # check 'show clock' is first cmd then dont add show clock cmd
+        dont_add_show_clock = False
+        if cmds.len >=1 and cmds[0].strip() == "show clock":
+            dont_add_show_clock = True
+
         # first run show clock if flag is set
-        if self.show_clock_flag:
+        if not dont_add_show_clock and self.show_clock_flag:
             show_clock_cmds = ["show clock"]
             # run the show_clock_cmds
             try:


### PR DESCRIPTION
# Please include a summary of the changes

tests_tools.py : check if in the list of cmds passed to _run_and_record_cmds() func has 'show clock' as first cmd to run. If yes then no need to add extra 'show clock' to these set of cmds.

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on

# Include the Issue number and link

Make sure to link the issue in the github PR UI 
#526 
# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
