### PR TITLE
Make role field optional in duts.yaml

### DIFF
--- a/tests/unittests/fixtures/fixture_duts_no_role.yaml
+++ b/tests/unittests/fixtures/fixture_duts_no_role.yaml
@@ -1,0 +1,35 @@
+duts:
+- mgmt_ip: 10.255.50.212
+  name: DSR01
+  neighbors:
+  - neighborDevice: DCBBW1
+    neighborPort: Ethernet1
+    port: Ethernet1
+  - neighborDevice: DCBBW2
+    neighborPort: Ethernet1
+    port: Ethernet2
+  - neighborDevice: DCBBE1
+    neighborPort: Ethernet1
+    port: Ethernet3
+  - neighborDevice: DCBBE2
+    neighborPort: Ethernet1
+    port: Ethernet4
+  password: cvp123!
+  transport: https
+  username: cvpadmin
+- mgmt_ip: 10.255.31.234
+  name: DCBBW1
+  neighbors:
+  - neighborDevice: DSR01
+    neighborPort: Ethernet1
+    port: Ethernet1
+  - neighborDevice: BLFW1
+    neighborPort: Ethernet1
+    port: Ethernet3
+  - neighborDevice: BLFW2
+    neighborPort: Ethernet1
+    port: Ethernet4
+  password: cvp123!
+  transport: https
+  username: cvpadmin
+servers: []

--- a/tests/unittests/test_tests_tools.py
+++ b/tests/unittests/test_tests_tools.py
@@ -346,6 +346,14 @@ def test_login_duts(loginfo, mocker):
     except ValueError as exception:
         assert str(exception) == "Invalid EOS conn type invalid_connection_type specified"
 
+    # assert value when no role in duts file
+
+    test_duts = read_yaml("tests/unittests/fixtures/fixture_duts_no_role.yaml")
+    test_parameters["parameters"]["eos_conn"] = "ssh"
+    actual_output = tests_tools.login_duts(test_parameters, test_duts)
+    dut_info = actual_output[0]
+    assert dut_info["role"] == ""
+
 
 def test_send_cmds_json(loginfo, logdebug, mocker):
     """Validates the functionality of send_cmds method"""

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -268,6 +268,8 @@ def login_duts(test_parameters, test_duts):
         login_ptr["mgmt_ip"] = dut["mgmt_ip"]
         login_ptr["username"] = dut["username"]
         login_ptr["password"] = dut["password"]
+        if "role" not in dut:
+            dut["role"] = ""
         login_ptr["role"] = dut["role"]
         login_ptr["neighbors"] = dut["neighbors"]
         login_ptr["transport"] = dut["transport"]

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -268,9 +268,7 @@ def login_duts(test_parameters, test_duts):
         login_ptr["mgmt_ip"] = dut["mgmt_ip"]
         login_ptr["username"] = dut["username"]
         login_ptr["password"] = dut["password"]
-        if "role" not in dut:
-            dut["role"] = ""
-        login_ptr["role"] = dut["role"]
+        login_ptr["role"] = dut.get("role", "")
         login_ptr["neighbors"] = dut["neighbors"]
         login_ptr["transport"] = dut["transport"]
         login_ptr["results_dir"] = test_parameters["parameters"]["results_dir"]


### PR DESCRIPTION
# Please include a summary of the changes

* tests_tools.py -> add role to be None in case role is not present in duts.yaml, so now Vane does not fail if role field is not present in duts file
* test_tests_tools.py -> added tests to verify the above change
* fixture_duts_no_neighbors.yaml -> fixture added for testing wherein duts do not have role

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/463

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
    
## New feature

Ensured current test cases pass and included newer test cases:

<img width="1391" alt="Screenshot 2023-09-26 at 1 13 23 PM" src="https://github.com/aristanetworks/vane/assets/123415500/805d6784-022b-4645-b7e1-20aabe0631a2">
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail