### PR TITLE
Add manual trigger for building CVP extension

### DIFF
--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -17,6 +17,9 @@ on:
     branches:
       - example-rpm-package-testing-branch
 
+  # Trigger a build manually from the browser interface
+  workflow-dispatch: {}
+
 # Variables
 env:
   CVP_BUILD_IMAGE: ghcr.io/aristanetworks/vane-cvp-build:latest

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -16,10 +16,9 @@ on:
   push:
     branches:
       - example-rpm-package-testing-branch
-      - gar-dispatch
 
   # Trigger a build manually from the browser interface
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 # Variables
 env:

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -18,7 +18,7 @@ on:
       - example-rpm-package-testing-branch
 
   # Trigger a build manually from the browser interface
-  workflow-dispatch: {}
+  workflow_dispatch: {}
 
 # Variables
 env:

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - example-rpm-package-testing-branch
+      - gar-dispatch
 
   # Trigger a build manually from the browser interface
   workflow_dispatch: {}


### PR DESCRIPTION
# Please include a summary of the changes

* .github/workflows/cvp-extension-builder.yml - add workflow_dispatch trigger - this should create a button that lets us manually start the workflow from the browser.

# Any specific logic/part of code you need extra attention on

N/A

# Include the Issue number and link

N/A

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

Needs to be in default branch to work
    
# CI pipeline result

N/A
  
# Verify Documentation Update

N/A
    
# Additional comments
