### PR TITLE
Changed generate duts file functionality to only generate duts file

### DIFF
--- a/tests/unittests/test_vane_cli.py
+++ b/tests/unittests/test_vane_cli.py
@@ -250,12 +250,9 @@ def test_main_definitions_and_duts(loginfo, logwarning, mocker):
     logwarning.assert_has_calls(logwarning_calls, any_order=False)
 
 
-def test_main_create_duts_file(loginfo, logwarning, mocker):
+def test_main_create_duts_file(loginfo, mocker):
     """Tests the --generate-duts-file flag"""
 
-    mocker.patch("vane.vane_cli.run_tests")
-    mocker.patch("vane.vane_cli.write_results")
-    mocker.patch("vane.vane_cli.download_test_results")
     mocker.patch("vane.tests_tools.create_duts_file", return_value="duts.yml")
 
     # mocking parse cli to test --generate-duts-file
@@ -274,8 +271,6 @@ def test_main_create_duts_file(loginfo, logwarning, mocker):
     )
     vane_cli.main()
 
-    assert vane.config.DUTS_FILE == "duts.yml"
-
     # assert info logs to ensure all the above methods executed without errors
     loginfo_calls = [
         call("Reading in input from command-line"),
@@ -283,16 +278,8 @@ def test_main_create_duts_file(loginfo, logwarning, mocker):
             "Generating DUTS File from topology: topology.yaml and "
             "inventory: inventory.yaml file.\n"
         ),
-        call("\n\n!VANE has completed without errors!\n\n"),
     ]
     loginfo.assert_has_calls(loginfo_calls, any_order=False)
-
-    # assert warning logs to ensure all the above methods executed without errors
-    logwarning_calls = [
-        call("Changing Definitions file name to definitions_sample.yaml"),
-        call("Changing DUTS file name to duts_sample.yaml"),
-    ]
-    logwarning.assert_has_calls(logwarning_calls, any_order=False)
 
 
 def test_main_generate_duts_from_topo(loginfo, logwarning, mocker):

--- a/vane/vane_cli.py
+++ b/vane/vane_cli.py
@@ -270,6 +270,13 @@ def main():
     if args.markers:
         print(f"{show_markers()}")
 
+    elif args.generate_duts_file:
+        logging.info(
+            f"Generating DUTS File from topology: {args.generate_duts_file[0]} and "
+            f"inventory: {args.generate_duts_file[1]} file.\n"
+        )
+        tests_tools.create_duts_file(args.generate_duts_file[0], args.generate_duts_file[1])
+
     elif args.generate_test_steps:
         logging.info(
             f"Generating test steps for test cases within {args.generate_test_steps} "
@@ -292,15 +299,6 @@ def main():
             if args.duts_file:
                 logging.warning(f"Changing DUTS file name to {args.duts_file}")
                 vane.config.DUTS_FILE = args.duts_file
-
-            if args.generate_duts_file:
-                logging.info(
-                    f"Generating DUTS File from topology: {args.generate_duts_file[0]} and "
-                    f"inventory: {args.generate_duts_file[1]} file.\n"
-                )
-                vane.config.DUTS_FILE = tests_tools.create_duts_file(
-                    args.generate_duts_file[0], args.generate_duts_file[1]
-                )
 
             if args.environment:
                 vane.config.ENVIRONMENT = args.environment


### PR DESCRIPTION
# Please include a summary of the changes

* vane_cli.py: changed logic to not run vane
* test_vane_Cli.py: ensure tests are passing with changed functionality


# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/555

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] functionality refactoring

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

Tests pass:

<img width="1335" alt="Screenshot 2023-10-02 at 1 32 10 PM" src="https://github.com/aristanetworks/vane/assets/123415500/3aa8031e-0876-4af7-a76d-94c3cf47e2b9">

    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
 
