### PR TITLE
issue-568: Updated testcase with ignore minidump directory 

### DIFF
--- a/nrfu_tests/test_system_hardware_coredump.py
+++ b/nrfu_tests/test_system_hardware_coredump.py
@@ -51,12 +51,12 @@ class CoreDumpFilesTests:
             self.output = f"Output of {tops.show_cmd} command is:\n{core_dump}"
             core_dump = core_dump["coreFiles"]
 
-            # If arBGP is enabled then ignoring minidump directory
-            if core_dump == ["minidump"]:
-                core_dump = []
+            # If arBGP is enabled then ignore minidump directory
+            if "minidump" in core_dump:
+                core_dump.remove("minidump")
             tops.actual_output["core_dump_files_not_found"] = not bool(core_dump)
 
-            # Output message formation in case test case fails.
+            # Output message formation in case the test case fails.
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = "Core dump files are found on the device."
 

--- a/nrfu_tests/test_system_hardware_coredump.py
+++ b/nrfu_tests/test_system_hardware_coredump.py
@@ -50,6 +50,10 @@ class CoreDumpFilesTests:
             )
             self.output = f"Output of {tops.show_cmd} command is:\n{core_dump}"
             core_dump = core_dump["coreFiles"]
+
+            # If arBGP is enabled then ignoring minidump directory
+            if core_dump == ["minidump"]:
+                core_dump = []
             tops.actual_output["core_dump_files_not_found"] = not bool(core_dump)
 
             # Output message formation in case test case fails.


### PR DESCRIPTION
# Please include a summary of the changes

test_system_hardware_coredump.py: Updated the logic to ignore minidump directory. 

# Any specific logic/part of code you need extra attention on

NA

#568 


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (Updated the code for arBGP enabled devices)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

1. Testcase pass when there is no dump files:
[report_2310191143.docx](https://github.com/aristanetworks/vane/files/13038709/report_2310191143.docx)
[report_2310191141.zip](https://github.com/aristanetworks/vane/files/13038715/report_2310191141.zip)

2. Testcase fails when there is dump file under /var/core: 
[report_2310191147.docx](https://github.com/aristanetworks/vane/files/13038720/report_2310191147.docx)
[report_2310191146.zip](https://github.com/aristanetworks/vane/files/13038724/report_2310191146.zip)



    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
