### PR TITLE
Updating skip functionality and fixing type error in NRFU4.3 test_routing_evpn_l2vni_imet testcase

### DIFF
--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -159,7 +159,7 @@ class EvpnRoutingTests:
                 if (show_bgp_command and "Not supported") in str(excep):
                     tops.output_msg = (
                         f"Skipping test case on {tops.dut_name} as {show_bgp_command} command"
-                        " unavailable, device might be in ribd mode."
+                        " is unavailable or device might be in ribd mode."
                     )
                     tests_tools.post_process_skip(
                         tops, self.test_routing_evpn_l2vni_imet, self.output
@@ -169,7 +169,7 @@ class EvpnRoutingTests:
             if "Interface does not exist" in str(excep):
                 # Skipping the testcase as Vxlan interfaces not configured / no L2 VNIs.
                 tops.output_msg = (
-                    f"Skipping test case on {tops.dut_name} as {vxlan_interface} interface does not"
+                    f"Skipping test case on {tops.dut_name} as interface {vxlan_interface} does not"
                     " exist / no L2 VNIs."
                 )
                 tests_tools.post_process_skip(tops, self.test_routing_evpn_l2vni_imet, self.output)

--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -137,7 +137,7 @@ class EvpnRoutingTests:
                             "evpnRoutes"
                         )
                         if not advertised_route_details:
-                            no_imet_routes_advertised[vrf].append(vni)
+                            no_imet_routes_advertised[vrf].append(str(vni))
 
                         tops.actual_output["vrfs"][vrf]["virtual_network_identifiers"][str(vni)] = {
                             "imet_routes_being_advertised": bool(advertised_route_details)
@@ -157,18 +157,21 @@ class EvpnRoutingTests:
             if skip_on_command_unavailable_check:
                 if (show_bgp_command and "Not supported") in str(excep):
                     tops.output_msg = (
-                        f"{show_bgp_command} command unavailable, device might be in ribd mode."
+                        f"Skipping test case on {tops.dut_name} as {show_bgp_command} command"
+                        " unavailable, device might be in ribd mode."
                     )
-                    pytest.skip(
-                        f"{show_bgp_command} command unavailable, device might be in ribd mode."
-                        " hence test skipped."
+                    tests_tools.post_process_skip(
+                        tops, self.test_routing_evpn_l2vni_imet, self.output
                     )
+                    pytest.skip(tops.output_msg)
 
             if "Interface does not exist" in str(excep):
-                tops.output_msg = f"{vxlan_interface} interface does not exist / no L2 VNIs."
-                pytest.skip(
-                    f"{vxlan_interface} interface does not exist / no L2 VNIs. hence test skipped."
+                tops.output_msg = (
+                    f"Skipping test case on {tops.dut_name} as {vxlan_interface} interface does not"
+                    " exist / no L2 VNIs."
                 )
+                tests_tools.post_process_skip(tops, self.test_routing_evpn_l2vni_imet, self.output)
+                pytest.skip(tops.output_msg)
 
             tops.actual_output = tops.output_msg = str(excep).split("\n", maxsplit=1)[0]
             logging.error(

--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -155,6 +155,7 @@ class EvpnRoutingTests:
 
         except (AssertionError, AttributeError, LookupError, EapiError) as excep:
             if skip_on_command_unavailable_check:
+                # Skipping the testcase as EVPN is not configured or device might be in ribd mode.
                 if (show_bgp_command and "Not supported") in str(excep):
                     tops.output_msg = (
                         f"Skipping test case on {tops.dut_name} as {show_bgp_command} command"
@@ -166,6 +167,7 @@ class EvpnRoutingTests:
                     pytest.skip(tops.output_msg)
 
             if "Interface does not exist" in str(excep):
+                # Skipping the testcase as Vxlan interfaces not configured / no L2 VNIs.
                 tops.output_msg = (
                     f"Skipping test case on {tops.dut_name} as {vxlan_interface} interface does not"
                     " exist / no L2 VNIs."


### PR DESCRIPTION
# Please include a summary of the changes
test_routing_evpn_l2vni_imet.py: Updating skip functionality and fixing type error in NRFU4.3

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/581

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (NRFU Tests)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# Reports

Passed reports when EVPN routes are advertised for all VNIs
[report_passed.docx](https://github.com/aristanetworks/vane/files/12916232/report_passed.docx)

Failed reports when test criteria does not met( tested using hardcoded output)
[report_failed.docx](https://github.com/aristanetworks/vane/files/12916229/report_failed.docx)

Skipped reports when vxlan not configured.
[report_skipped_as_vxlan_interface_not_found.docx](https://github.com/aristanetworks/vane/files/12981686/report_skipped_as_vxlan_interface_not_found.docx)


Skipped reports when ribd model protocol is enabled. EVPN is not configured
[report_Skipped_when_device_is_in_ribd_mode.docx](https://github.com/aristanetworks/vane/files/12981680/report_Skipped_when_device_is_in_ribd_mode.docx)


HTML reports
[html_reports.zip](https://github.com/aristanetworks/vane/files/12981690/html_reports.zip)

