### PR TITLE
Removed generate-duts-from-topo functionality and modified tests

### DIFF
--- a/tests/unittests/test_tests_tools.py
+++ b/tests/unittests/test_tests_tools.py
@@ -861,35 +861,6 @@ def test_export_text():
     shutil.rmtree("text", ignore_errors=True)
 
 
-def test_generate_duts_file():
-    """Validates generation of duts file from duts data"""
-    dut_file = "dut_file.yml"
-    dut = {
-        "DSR01": {
-            "ip_addr": "192.168.0.9",
-            "node_type": "veos",
-            "neighbors": [
-                {"neighborDevice": "DCBBW1", "neighborPort": "Ethernet1", "port": "Ethernet1"},
-                {"neighborDevice": "DCBBW2", "neighborPort": "Ethernet1", "port": "Ethernet2"},
-            ],
-        }
-    }
-
-    assert not os.path.exists(dut_file)
-    with open(dut_file, "w", encoding="utf-8") as file:
-        tests_tools.generate_duts_file(dut, file, "username", "password!")
-
-    # check if yaml file got created
-    assert os.path.isfile(dut_file)
-
-    # check if yaml file got written to correctly
-    with open(dut_file, "r", encoding="utf-8") as input_yaml:
-        actual = yaml.safe_load(input_yaml)
-        assert dut["DSR01"]["neighbors"] == actual[0]["neighbors"]
-        assert dut["DSR01"]["ip_addr"] == actual[0]["mgmt_ip"]
-    os.remove(dut_file)
-
-
 def test_create_duts_file():
     """Validates generation of duts file from topology and inventory file
     FIXTURES NEEDED: fixture_topology.yaml, fixture_inventory.yaml"""

--- a/tests/unittests/test_vane_cli.py
+++ b/tests/unittests/test_vane_cli.py
@@ -174,19 +174,6 @@ def test_show_markers(mocker):
     assert actual_output == expected_output
 
 
-def test_create_duts_from_topo():
-    """Validates functionality of create_duts_from_topo method.
-    REQUIRES there to be a tests/unittests/fixtures/test_topology.yaml
-    in this folder for test to pass"""
-
-    topology_file = "tests/unittests/fixtures/test_topology.yaml"
-    vane_cli.create_duts_from_topo(topology_file)
-    # validates the creation of the duts file, its content is tested in the test
-    # written for test_tools.generate_duts_file
-    assert os.path.isfile("tests/unittests/fixtures/test_topology.yaml_duts.yaml")
-    os.remove("tests/unittests/fixtures/test_topology.yaml_duts.yaml")
-
-
 def test_download_test_results(loginfo):
     """Validates if a zip archive got created and stored in the TEST RESULTS
     ARCHIVE folder"""
@@ -223,7 +210,6 @@ def test_main_definitions_and_duts(loginfo, logwarning, mocker):
             duts_file="duts_sample.yaml",
             environment="test",
             generate_duts_file=None,
-            generate_duts_from_topo=None,
             generate_test_steps=None,
             markers=False,
             nrfu=False,
@@ -266,7 +252,6 @@ def test_main_create_duts_file(loginfo, logwarning, mocker):
             duts_file="duts_sample.yaml",
             environment="test",
             generate_duts_file=["topology.yaml", "inventory.yaml"],
-            generate_duts_from_topo=None,
             generate_test_steps=None,
             markers=False,
             nrfu=False,
@@ -301,7 +286,6 @@ def test_main_generate_duts_from_topo(loginfo, logwarning, mocker):
     mocker.patch("vane.vane_cli.run_tests")
     mocker.patch("vane.vane_cli.write_results")
     mocker.patch("vane.vane_cli.download_test_results")
-    mocker.patch("vane.vane_cli.create_duts_from_topo")
 
     # mocking parse cli to test --generate-duts-from-topo
     mocker.patch(
@@ -311,7 +295,6 @@ def test_main_generate_duts_from_topo(loginfo, logwarning, mocker):
             duts_file="duts_sample.yaml",
             environment="test",
             generate_duts_file=None,
-            generate_duts_from_topo=["topology.yaml"],
             generate_test_steps=None,
             markers=False,
             nrfu=False,
@@ -322,7 +305,6 @@ def test_main_generate_duts_from_topo(loginfo, logwarning, mocker):
     # assert info logs to ensure all the above methods executed without errors
     loginfo_calls = [
         call("Reading in input from command-line"),
-        call("Generating DUTS File from topology: topology.yaml file.\n"),
         call("\n\n!VANE has completed without errors!\n\n"),
     ]
     loginfo.assert_has_calls(loginfo_calls, any_order=False)
@@ -351,7 +333,6 @@ def test_main_write_test_steps(loginfo, mocker):
             duts_file="duts_sample.yaml",
             environment="test",
             generate_duts_file=None,
-            generate_duts_from_topo=None,
             generate_test_steps="test_directory",
             markers=False,
         ),

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -831,36 +831,6 @@ def export_text(text_file, text_data, dut_name):
         sys.exit(1)
 
 
-def generate_duts_file(dut, file, username, password):
-    """Util function to take in an individual dut and print
-    its relevant data to a given file.
-
-    Args:
-        dut (dict): device structure
-        file (io): file to write duts data to
-        username, password (str): user credentials
-    """
-    dut_dict = {}
-    try:
-        for data in dut:
-            if dut[data]["node_type"] == "veos":
-                dut_dict = [
-                    {
-                        "mgmt_ip": dut[data]["ip_addr"],
-                        "name": data,
-                        "neighbors": dut[data]["neighbors"],
-                        "password": password,
-                        "transport": "https",
-                        "username": username,
-                        "role": "",
-                    }
-                ]
-        if dut_dict:
-            yaml.dump(dut_dict, file)
-    except yaml.YAMLError as err:
-        print(f"DUTs creation for {file} failed due to exception {err}")
-
-
 def create_duts_file(topology_file, inventory_file):
     """Automatically generate a DUTs file
 

--- a/vane/vane_cli.py
+++ b/vane/vane_cli.py
@@ -39,7 +39,6 @@ from contextlib import redirect_stdout
 from datetime import datetime
 import shutil
 import os
-import yaml
 import pytest
 from vane import tests_client
 from vane import report_client
@@ -84,13 +83,6 @@ def parse_cli():
         help="Create a duts file from topology and inventory file",
         nargs=2,
         metavar=("topology_file", "inventory_file"),
-    )
-
-    parser.add_argument(
-        "--generate-duts-from-topo",
-        help="Generate a duts file from an ACT topology file.",
-        nargs=1,
-        metavar=("topology_file"),
     )
 
     parser.add_argument(
@@ -215,36 +207,6 @@ def show_markers():
     return marker_list
 
 
-def create_duts_from_topo(topology_file):
-    """
-    Util function responsible for reading in topology file,
-    calling on test tools to create duts file from the data
-    gathered from the topo file.
-
-    Args:
-        topology_file (str): Path and name of topology file
-    """
-    # Open the topology file in read only
-    try:
-        with open(topology_file, "r", encoding="utf-8") as file:
-            topology = yaml.safe_load(file)
-    except FileNotFoundError:
-        print("No valid topology file provided.")
-        return
-
-    # Output data to duts file
-    if topology["nodes"]:
-        username = topology["veos"]["username"]
-        password = topology["veos"]["password"]
-        topo_name = topology_file.split(".yml")[0]
-        output_file = topo_name + "_duts.yaml"
-
-        with open(output_file, "w", encoding="utf-8") as file:
-            file.write("duts: \n")
-            for node in topology["nodes"]:
-                tests_tools.generate_duts_file(node, file, username, password)
-
-
 def download_test_results():
     """
     function responsible for creating a zip of the
@@ -304,12 +266,6 @@ def main():
 
             if args.environment:
                 vane.config.ENVIRONMENT = args.environment
-
-            if args.generate_duts_from_topo:
-                logging.info(
-                    f"Generating DUTS File from topology: {args.generate_duts_from_topo[0]} file.\n"
-                )
-                create_duts_from_topo(args.generate_duts_from_topo[0])
 
         run_tests(vane.config.DEFINITIONS_FILE, vane.config.DUTS_FILE)
         write_results(vane.config.DEFINITIONS_FILE)


### PR DESCRIPTION
# Please include a summary of the changes

* tests_tools.py: removed generate_duts_file method called from vane_cli to generate duts from topo
* vane_cli.py: removed create_cuts_from_topo method called when --generate-duts-from-topo flag is used
* modified the tests for these two modules

# Include the Issue number and link

#571 

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Refactor

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

All tests pass:

<img width="1347" alt="Screenshot 2023-10-16 at 2 14 08 PM" src="https://github.com/aristanetworks/vane/assets/123415500/baa0b257-fac5-4924-aa9e-1162c6ea9a99">
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
 
