### PR TITLE
Issue-585: remove pytest generated files from test_walk_dir

### DIFF
--- a/tests/unittests/test_tests_step_client.py
+++ b/tests/unittests/test_tests_step_client.py
@@ -79,8 +79,6 @@ def test_write_test_steps(loginfo, mocker):
     loginfo.assert_has_calls(loginfo_calls, any_order=False)
 
 
-# Skip test case if not ran in GitHub
-@pytest.mark.skipif(IN_GITHUB_ACTIONS is not True, reason="Test only works in Github Actions.")
 def test_walk_dir(logdebug, mocker):
     "Unit Test for TestStepClient object, method walk_dir"
 
@@ -89,24 +87,21 @@ def test_walk_dir(logdebug, mocker):
     test_steps.walk_dir()
     mocker_object.assert_called_once()
 
-    # These files are unique to git actions ci environment
-    # This test will fail if ran locally
-    files1 = ["__init__.cpython-39.pyc", "test_host.cpython-39-pytest-7.4.0.pyc"]
-    files2 = [
-        "test_definition.yaml",
-        "test_host.py",
-        "test_definition_regenerated.yaml",
+    files = [
         "__init__.py",
+        "test_definition.yaml",
+        "test_definition_regenerated.yaml",
+        "test_host.py",
     ]
 
     logdebug_calls = [
-        call(f"Set Test Step Client object directory to {[TEST_DIR]}"),
-        call(f"Walking directory {TEST_DIR} for test cases"),
-        call(f"Discovered files {files1} in directory {TEST_DIR}"),
-        call(f"Discovered files {files2} in directory {TEST_DIR}"),
-        call(f"Discovered test files: {TEST_FILE} for parsing"),
+        (f"Set Test Step Client object directory to {[TEST_DIR]}"),
+        (f"Walking directory {TEST_DIR} for test cases"),
+        (f"Discovered files {files} in directory {TEST_DIR}"),
+        (f"Discovered test files: {TEST_FILE} for parsing"),
     ]
-    logdebug.assert_has_calls(logdebug_calls, any_order=False)
+    for debug_msg in logdebug_calls:
+        logdebug.assert_any_call(debug_msg)
 
 
 def test_parse_file(loginfo, logdebug, mocker):

--- a/vane/test_step_client.py
+++ b/vane/test_step_client.py
@@ -67,6 +67,8 @@ class TestStepClient:
             logging.debug(f"Walking directory {test_dir} for test cases")
             test_files = []
             for root, _dirs, files in os.walk(test_dir, topdown=False):
+                # sort the files
+                files.sort()
                 logging.debug(f"Discovered files {files} in directory {test_dir}")
                 test_files.extend(
                     os.path.join(root, name)


### PR DESCRIPTION
# Please include a summary of the changes

* tests/unittests/test_tests_step_client.py - remove the auto generated file from the tests. They are not relevant to test. This would get rid of problem of pytest version in those files.
* vane/test_step_client.py - sort the files so that log generated is predictable and always matches a set pattern. Otherwise os.walk() returns files in no particular order.

# Any specific logic/part of code you need extra attention on
would the sorting of files in vane/test_step_client will create any performance issue?

# Include the Issue number and link
#585 
Make sure to link the issue in the github PR UI 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Locally by running pytest for unit testing.
## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
