### PR TITLE
Automate Vane CVP extension installation/uninstallation

### DIFF
--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -124,20 +124,25 @@ jobs:
           if ${PUB_BRANCH} == true; then
             tag=""
           else
-            tag="provisional"
+            tag="-provisional"
           fi
           distro_dir="vane-cvp-${version_str}${tag}"
           mkdir ${distro_dir}
-          echo "distro_dir=${distro_dir}" >> $GITHUB_ENV
+          #
+          # Put the distro_dir in the environment
+          #
+          echo "DISTRO_DIR=${distro_dir}" >> $GITHUB_ENV
+          # XXX
+          ls -la
 
       - name: Copy the installation scripts and the rpm into the distribution directory
         run: |
-          cp resources/vane-cvp-*.sh ${env.distro_dir}/
-          cp rpms/*.rpm ${env.distro_dir}/
+          cp resources/vane-cvp-*.sh ${DISTRO_DIR}/
+          cp rpms/*.rpm ${DISTRO_DIR}/
 
       - name: Archive the distribution directory
         run: |
-          tar czvf ${env.distro_dir}.tgz ${env.distro_dir}
+          tar czvf ${DISTRO_DIR}.tgz ${DISTRO_DIR}
 
       - name: Save the tarball to the RPM branch
         run: |
@@ -158,9 +163,9 @@ jobs:
           # to true since it will fail when trying to delete '.' and '..'
           #
           shopt -s dotglob extglob
-          rm -rf !(.git|${env.distro_dir}.tgz) || true
+          rm -rf !(.git|${DISTRO_DIR}.tgz) || true
           #
-          if [ $(git ls-files --others | grep ${env.distro_dir}.tgz ) ] ; then
+          if [ $(git ls-files --others | grep ${DISTRO_DIR}) ] ; then
             echo "Uploading new RPM package"
             # XXX
             # # Copy the version of README from the coverage-badge branch

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -87,7 +87,6 @@ jobs:
       # We can't use the CVP_BUILD_IMAGE variable here, because the context is not
       # available in the "job" scope
       image: ghcr.io/aristanetworks/vane-cvp-build:latest
-      options: --user root
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -103,11 +103,21 @@ jobs:
         run: |
           make rpm-cvp
 
+      - name: Copy the installation scripts into the rpms directory for packaging
+        run: |
+          cp resources/vane-cvp-*install.sh rpms/
+
       - name: Save the rpm package as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: vane-cvp-rpm
-          path: |
-            rpms/vane-cvp-*.rpm
-            resources/vane-cvp-install.sh
-            resources/vane-cvp-uninstall.sh
+          path: rpms/
+
+      # - name: Save the rpm package as an artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: vane-cvp-rpm
+      #     path: |
+      #       rpms/vane-cvp-*.rpm
+      #       resources/vane-cvp-install.sh
+      #       resources/vane-cvp-uninstall.sh

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -107,18 +107,11 @@ jobs:
         run: |
           cp resources/vane-cvp-*install.sh rpms/
           chmod +x rpms/vane-cvp-*install.sh
+          cd rpms
+          tar cvzf vane-cvp.tar.gz *.rpm vane-cvp-*install.sh
 
       - name: Save the rpm package as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: vane-cvp-rpm
-          path: rpms/
-
-      # - name: Save the rpm package as an artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: vane-cvp-rpm
-      #     path: |
-      #       rpms/vane-cvp-*.rpm
-      #       resources/vane-cvp-install.sh
-      #       resources/vane-cvp-uninstall.sh
+          path: rpms/vane-cvp.tar.gz

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -206,6 +206,8 @@ jobs:
 
       - name: Save the tarball to the RPM branch
         run: |
+          git config --global --add safe.directory /__w/vane/vane
+          pwd
           #
           # Define the vane_package name
           #

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -29,9 +29,65 @@ env:
 # Job definitions
 jobs:
 
+  # Create the RPM package and upload the package as an artifact
+  test_git_commands:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        # with:
+        #   fetch-depth: 0
+
+      - name: Save the tarball to the RPM branch
+        run: |
+          ls -la
+          pwd
+          git status || true
+          git config user.name actions-user
+          git config user.email "actions@github.com"
+          #
+          # List the files in the repo
+          #
+          ls -la
+          #
+          # edit a file
+          #
+          echo "blah" > gartest.txt
+          #
+          # Show the current repo status
+          #
+          git status
+          #
+          # Remove all the files in the repo except the .git folder,
+          # the README file, and the test file. 'or' the command
+          # to true since it will fail when trying to delete '.' and '..'
+          #
+          shopt -s dotglob extglob
+          rm -rf !(.git|gartest.txt) || true
+          #
+          if [ $(git ls-files --others | grep gartest.txt) ] ; then
+            echo "Uploading new RPM package"
+            # XXX
+            # # Copy the version of README from the coverage-badge branch
+            # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
+            # Add and commit all the changes we just made, so we end up committing
+            # just the README and the distribution package to the rpm-packages branch
+            git add --all
+            git status
+            # Make the commit, but it will not be saved in GitHub on the working branch
+            git commit -am "Uploading new RPM package"
+            # Push the commit to the rpm-packages branch (not to the working branch or develop)
+            git push -f origin ${{ github.ref }}:gar-rpm-packages
+          fi
+
   # Create the container we use to build the RPM
   #   This is a Centos container to match the CVP environment
   create_centos_build_container:
+
+    # XXX
+    needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:
@@ -55,6 +111,9 @@ jobs:
   # Create the container that will be running in the CVP environment
   #   This is a minimal container with Vane and its requirements installed
   create_cvp_container:
+
+    # XXX
+    needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -150,8 +150,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
-        # with:
-        #   fetch-depth: 0
 
       - name: Download the CVP Vane image file artifact we created in the previous job
         uses: actions/download-artifact@v3
@@ -169,85 +167,93 @@ jobs:
       #     chmod +x rpms/vane-cvp-*.sh
       #     cd rpms
       #     tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*.sh
-      #
-      # - name: Save the rpm package as an artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: vane-cvp-rpm
-      #     path: rpms/vane-cvp-rpm.tar.gz
 
       - name: Create a vane-cvp distribution directory based on the version being built
         env:
+          # Check if we are on a published branch (main or develop)
           PUB_BRANCH: ${{ contains(fromJSON('["main", "develop"]'), github.ref) }}
         run: |
           version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
           if ${PUB_BRANCH} == true; then
+            # If on a published branch, the tag is empty
             tag=""
           else
+            # If not on a published branch, append "-provisional" to the distribution name
             tag="-provisional"
           fi
-          distro_dir="vane-cvp-${version_str}${tag}"
-          mkdir ${distro_dir}
           #
-          # Put the distro_dir in the environment
+          # Create the distribution directory
           #
-          echo "DISTRO_DIR=${distro_dir}" >> $GITHUB_ENV
-          # XXX
+          dist_name="vane-cvp-${version_str}${tag}"
+          mkdir ${dist_name}
+          #
+          # List the current directory to show the newly created directory
+          #
           ls -la
+          #
+          # Put the dist_name in the environment as DIST_NAME
+          #
+          echo "DIST_NAME=${dist_name}" >> $GITHUB_ENV
 
       - name: Copy the installation scripts and the rpm into the distribution directory
         run: |
-          cp resources/vane-cvp-*.sh ${DISTRO_DIR}/
-          cp rpms/*.rpm ${DISTRO_DIR}/
+          cp resources/vane-cvp-*.sh ${DIST_NAME}/
+          cp rpms/*.rpm ${DIST_NAME}/
 
       - name: Archive the distribution directory
         run: |
-          tar czvf ${DISTRO_DIR}.tgz ${DISTRO_DIR}
+          tar czvf ${DIST_NAME}.tgz ${DIST_NAME}
 
-      - name: Save the tarball to the RPM branch
-        run: |
-          git config --global --add safe.directory /__w/vane/vane
-          pwd
-          #
-          # Define the vane_package name
-          #
-          vane_package=${DISTRO_DIR}.tgz
-          #
-          # Set some git values
-          #
-          git status || true
-          git config user.name actions-user
-          git config user.email "actions@github.com"
-          #
-          # List the files in the repo
-          #
-          ls -la
-          #
-          # Show the current repo status
-          #
-          git status
-          #
-          # Remove all the files in the repo except the .git folder,
-          # the README file, and the coverage file. 'or' the command
-          # to true since it will fail when trying to delete '.' and '..'
-          #
-          shopt -s dotglob extglob
-          rm -rf !(.git|${vane_package}) || true
-          #
-          # If the vane_package exists, push it to the rpm-packages branch
-          #
-          if [ $(git ls-files --others | grep ${vane_package}) ] ; then
-            echo "Uploading new RPM package"
-            # XXX
-            # Copy the version of README from the rpm-packages branch
-            #
-            # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
-            # Add and commit all the changes we just made, so we end up committing
-            # just the README and the RPM package to the coverage-badge branch
-            git add --all
-            git status
-            # Make the commit, but it will not be saved in GitHub on the working branch
-            git commit -am "Uploading new RPM package"
-            # Push the commit to the rpm-packages branch (not to the working branch or develop)
-            git push -f origin ${{ github.ref }}:gar-rpm-packages
-          fi
+      - name: Save the rpm package as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.DIST_NAME }}
+          path: ${{ env.DIST_NAME }}.tgz
+
+      # - name: Save the tarball to the RPM branch
+      #   run: |
+      #     git config --global --add safe.directory /__w/vane/vane
+      #     pwd
+      #     #
+      #     # Define the vane_package name
+      #     #
+      #     vane_package=${DIST_NAME}.tgz
+      #     #
+      #     # Set some git values
+      #     #
+      #     git status || true
+      #     git config user.name actions-user
+      #     git config user.email "actions@github.com"
+      #     #
+      #     # List the files in the repo
+      #     #
+      #     ls -la
+      #     #
+      #     # Show the current repo status
+      #     #
+      #     git status
+      #     #
+      #     # Remove all the files in the repo except the .git folder,
+      #     # the README file, and the coverage file. 'or' the command
+      #     # to true since it will fail when trying to delete '.' and '..'
+      #     #
+      #     shopt -s dotglob extglob
+      #     rm -rf !(.git|${vane_package}) || true
+      #     #
+      #     # If the vane_package exists, push it to the rpm-packages branch
+      #     #
+      #     if [ $(git ls-files --others | grep ${vane_package}) ] ; then
+      #       echo "Uploading new RPM package"
+      #       # XXX
+      #       # Copy the version of README from the rpm-packages branch
+      #       #
+      #       # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
+      #       # Add and commit all the changes we just made, so we end up committing
+      #       # just the README and the RPM package to the coverage-badge branch
+      #       git add --all
+      #       git status
+      #       # Make the commit, but it will not be saved in GitHub on the working branch
+      #       git commit -am "Uploading new RPM package"
+      #       # Push the commit to the rpm-packages branch (not to the working branch or develop)
+      #       git push -f origin ${{ github.ref }}:gar-rpm-packages
+      #     fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Copy the installation scripts into the rpms directory for packaging
         run: |
           cp resources/vane-cvp-*install.sh rpms/
+          chmod +x rpms/vane-cvp-*install.sh
 
       - name: Save the rpm package as an artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -108,10 +108,10 @@ jobs:
           cp resources/vane-cvp-*install.sh rpms/
           chmod +x rpms/vane-cvp-*install.sh
           cd rpms
-          tar cvzf vane-cvp.tar.gz *.rpm vane-cvp-*install.sh
+          tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*install.sh
 
       - name: Save the rpm package as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: vane-cvp-rpm
-          path: rpms/vane-cvp.tar.gz
+          path: rpms/vane-cvp-rpm.tar.gz

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -103,15 +103,73 @@ jobs:
         run: |
           make rpm-cvp
 
-      - name: Copy the installation scripts into the rpms directory for packaging
-        run: |
-          cp resources/vane-cvp-*.sh rpms/
-          chmod +x rpms/vane-cvp-*.sh
-          cd rpms
-          tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*.sh
+      # - name: Copy the installation scripts into the rpms directory for packaging
+      #   run: |
+      #     cp resources/vane-cvp-*.sh rpms/
+      #     chmod +x rpms/vane-cvp-*.sh
+      #     cd rpms
+      #     tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*.sh
+      #
+      # - name: Save the rpm package as an artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: vane-cvp-rpm
+      #     path: rpms/vane-cvp-rpm.tar.gz
 
-      - name: Save the rpm package as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: vane-cvp-rpm
-          path: rpms/vane-cvp-rpm.tar.gz
+      - name: Create a vane-cvp distribution directory based on the version being built
+        env:
+          PUB_BRANCH: ${{ contains(github.ref, ['main', 'develop']) }}
+        run: |
+          version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
+          if ${PUB_BRANCH} == true; then
+            tag=""
+          else
+            tag="provisional"
+          fi
+          distro_dir="vane-cvp-${version_str}${tag}"
+          mkdir ${distro_dir}
+          echo "distro_dir=${distro_dir}" >> $GITHUB_ENV
+
+      - name: Copy the installation scripts and the rpm into the distribution directory
+        run: |
+          cp resources/vane-cvp-*.sh ${env.distro_dir}/
+          cp rpms/*.rpm ${env.distro_dir}/
+
+      - name: Archive the distribution directory
+        run: |
+          tar czvf ${env.distro_dir}.tgz ${env.distro_dir}
+
+      - name: Save the tarball to the RPM branch
+        git status || true
+        git config --local user.name actions-user
+        git config --local user.email "actions@github.com"
+        #
+        # List the files in the repo
+        #
+        ls -la
+        #
+        # Show the current repo status
+        #
+        git status
+        #
+        # Remove all the files in the repo except the .git folder,
+        # the README file, and the coverage file. 'or' the command
+        # to true since it will fail when trying to delete '.' and '..'
+        #
+        shopt -s dotglob extglob
+        rm -rf !(.git|${env.distro_dir}.tgz) || true
+        #
+        if [ $(git ls-files --others | grep ${env.distro_dir}.tgz ) ] ; then
+          echo "Uploading new RPM package"
+          # XXX
+          # # Copy the version of README from the coverage-badge branch
+          # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
+          # Add and commit all the changes we just made, so we end up committing
+          # just the README and the coverage badge to the coverage-badge branch
+          git add --all
+          git status
+          # Make the commit, but it will not be saved in GitHub on the working branch
+          git commit -am "Uploading new RPM package"
+          # Push the commit to the rpm-packages branch (not to the working branch or develop)
+          git push -f origin ${{ github.ref }}:gar-rpm-packages
+        fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -105,10 +105,10 @@ jobs:
 
       - name: Copy the installation scripts into the rpms directory for packaging
         run: |
-          cp resources/vane-cvp-*install.sh rpms/
-          chmod +x rpms/vane-cvp-*install.sh
+          cp resources/vane-cvp-*.sh rpms/
+          chmod +x rpms/vane-cvp-*.sh
           cd rpms
-          tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*install.sh
+          tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*.sh
 
       - name: Save the rpm package as an artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Create a vane-cvp distribution directory based on the version being built
         env:
-          PUB_BRANCH: ${{ contains(github.ref, ['main', 'develop']) }}
+          PUB_BRANCH: ${{ contains(fromJSON('["main", "develop"]'), github.ref) }}
         run: |
           version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
           if ${PUB_BRANCH} == true; then

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -107,4 +107,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: vane-cvp-rpm
-          path: rpms/
+          path: |
+            rpms/vane-cvp-*.rpm
+            resources/vane-cvp-install.sh
+            resources/vane-cvp-uninstall.sh

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -87,10 +87,11 @@ jobs:
       # We can't use the CVP_BUILD_IMAGE variable here, because the context is not
       # available in the "job" scope
       image: ghcr.io/aristanetworks/vane-cvp-build:latest
+      options: --user root
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         # with:
         #   fetch-depth: 0
 

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -29,65 +29,9 @@ env:
 # Job definitions
 jobs:
 
-  # # Create the RPM package and upload the package as an artifact
-  # test_git_commands:
-  #
-  #   runs-on: ubuntu-latest
-  #
-  #   steps:
-  #     - name: Check out the repository
-  #       uses: actions/checkout@v3
-  #       # with:
-  #       #   fetch-depth: 0
-  #
-  #     - name: Save the tarball to the RPM branch
-  #       run: |
-  #         ls -la
-  #         pwd
-  #         git status || true
-  #         git config user.name actions-user
-  #         git config user.email "actions@github.com"
-  #         #
-  #         # List the files in the repo
-  #         #
-  #         ls -la
-  #         #
-  #         # edit a file
-  #         #
-  #         echo "blah" > gartest.txt
-  #         #
-  #         # Show the current repo status
-  #         #
-  #         git status
-  #         #
-  #         # Remove all the files in the repo except the .git folder,
-  #         # the README file, and the test file. 'or' the command
-  #         # to true since it will fail when trying to delete '.' and '..'
-  #         #
-  #         shopt -s dotglob extglob
-  #         rm -rf !(.git|gartest.txt) || true
-  #         #
-  #         if [ $(git ls-files --others | grep gartest.txt) ] ; then
-  #           echo "Uploading new RPM package"
-  #           # XXX
-  #           # # Copy the version of README from the coverage-badge branch
-  #           # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
-  #           # Add and commit all the changes we just made, so we end up committing
-  #           # just the README and the distribution package to the rpm-packages branch
-  #           git add --all
-  #           git status
-  #           # Make the commit, but it will not be saved in GitHub on the working branch
-  #           git commit -am "Uploading new RPM package"
-  #           # Push the commit to the rpm-packages branch (not to the working branch or develop)
-  #           git push -f origin ${{ github.ref }}:gar-rpm-packages
-  #         fi
-
   # Create the container we use to build the RPM
   #   This is a Centos container to match the CVP environment
   create_centos_build_container:
-
-    # # XXX
-    # needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:
@@ -111,9 +55,6 @@ jobs:
   # Create the container that will be running in the CVP environment
   #   This is a minimal container with Vane and its requirements installed
   create_cvp_container:
-
-    # # XXX
-    # needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:
@@ -161,24 +102,21 @@ jobs:
           ls -la
           make rpm-cvp
 
-      # - name: Copy the installation scripts into the rpms directory for packaging
-      #   run: |
-      #     cp resources/vane-cvp-*.sh rpms/
-      #     chmod +x rpms/vane-cvp-*.sh
-      #     cd rpms
-      #     tar cvzf vane-cvp-rpm.tar.gz *.rpm vane-cvp-*.sh
-
       - name: Create a vane-cvp distribution directory based on the version being built
         env:
           # Check if we are on a published branch (main or develop)
           PUB_BRANCH: ${{ contains(fromJSON('["main", "develop"]'), github.ref) }}
         run: |
+          #
+          # Get the version string from the pyproject.toml file
+          #
           version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
+          #
+          # If not on a published branch, append a provisional tag to the distribution name
+          #
           if ${PUB_BRANCH} == true; then
-            # If on a published branch, the tag is empty
             tag=""
           else
-            # If not on a published branch, append "-provisional" to the distribution name
             tag="-provisional"
           fi
           #
@@ -204,56 +142,10 @@ jobs:
         run: |
           tar czvf ${DIST_NAME}.tgz ${DIST_NAME}
 
-      - name: Save the rpm package as an artifact
+      - name: Save the rpm package as an artifact in GitHub
+        # 'name' is the artifact name in GitHub
+        # 'path' is the rpm package to be saved
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.DIST_NAME }}
+          name: ${{ env.DIST_NAME }}-rpm
           path: ${{ env.DIST_NAME }}.tgz
-
-      # - name: Save the tarball to the RPM branch
-      #   run: |
-      #     git config --global --add safe.directory /__w/vane/vane
-      #     pwd
-      #     #
-      #     # Define the vane_package name
-      #     #
-      #     vane_package=${DIST_NAME}.tgz
-      #     #
-      #     # Set some git values
-      #     #
-      #     git status || true
-      #     git config user.name actions-user
-      #     git config user.email "actions@github.com"
-      #     #
-      #     # List the files in the repo
-      #     #
-      #     ls -la
-      #     #
-      #     # Show the current repo status
-      #     #
-      #     git status
-      #     #
-      #     # Remove all the files in the repo except the .git folder,
-      #     # the README file, and the coverage file. 'or' the command
-      #     # to true since it will fail when trying to delete '.' and '..'
-      #     #
-      #     shopt -s dotglob extglob
-      #     rm -rf !(.git|${vane_package}) || true
-      #     #
-      #     # If the vane_package exists, push it to the rpm-packages branch
-      #     #
-      #     if [ $(git ls-files --others | grep ${vane_package}) ] ; then
-      #       echo "Uploading new RPM package"
-      #       # XXX
-      #       # Copy the version of README from the rpm-packages branch
-      #       #
-      #       # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
-      #       # Add and commit all the changes we just made, so we end up committing
-      #       # just the README and the RPM package to the coverage-badge branch
-      #       git add --all
-      #       git status
-      #       # Make the commit, but it will not be saved in GitHub on the working branch
-      #       git commit -am "Uploading new RPM package"
-      #       # Push the commit to the rpm-packages branch (not to the working branch or develop)
-      #       git push -f origin ${{ github.ref }}:gar-rpm-packages
-      #     fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -29,65 +29,65 @@ env:
 # Job definitions
 jobs:
 
-  # Create the RPM package and upload the package as an artifact
-  test_git_commands:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
-        # with:
-        #   fetch-depth: 0
-
-      - name: Save the tarball to the RPM branch
-        run: |
-          ls -la
-          pwd
-          git status || true
-          git config user.name actions-user
-          git config user.email "actions@github.com"
-          #
-          # List the files in the repo
-          #
-          ls -la
-          #
-          # edit a file
-          #
-          echo "blah" > gartest.txt
-          #
-          # Show the current repo status
-          #
-          git status
-          #
-          # Remove all the files in the repo except the .git folder,
-          # the README file, and the test file. 'or' the command
-          # to true since it will fail when trying to delete '.' and '..'
-          #
-          shopt -s dotglob extglob
-          rm -rf !(.git|gartest.txt) || true
-          #
-          if [ $(git ls-files --others | grep gartest.txt) ] ; then
-            echo "Uploading new RPM package"
-            # XXX
-            # # Copy the version of README from the coverage-badge branch
-            # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
-            # Add and commit all the changes we just made, so we end up committing
-            # just the README and the distribution package to the rpm-packages branch
-            git add --all
-            git status
-            # Make the commit, but it will not be saved in GitHub on the working branch
-            git commit -am "Uploading new RPM package"
-            # Push the commit to the rpm-packages branch (not to the working branch or develop)
-            git push -f origin ${{ github.ref }}:gar-rpm-packages
-          fi
+  # # Create the RPM package and upload the package as an artifact
+  # test_git_commands:
+  #
+  #   runs-on: ubuntu-latest
+  #
+  #   steps:
+  #     - name: Check out the repository
+  #       uses: actions/checkout@v3
+  #       # with:
+  #       #   fetch-depth: 0
+  #
+  #     - name: Save the tarball to the RPM branch
+  #       run: |
+  #         ls -la
+  #         pwd
+  #         git status || true
+  #         git config user.name actions-user
+  #         git config user.email "actions@github.com"
+  #         #
+  #         # List the files in the repo
+  #         #
+  #         ls -la
+  #         #
+  #         # edit a file
+  #         #
+  #         echo "blah" > gartest.txt
+  #         #
+  #         # Show the current repo status
+  #         #
+  #         git status
+  #         #
+  #         # Remove all the files in the repo except the .git folder,
+  #         # the README file, and the test file. 'or' the command
+  #         # to true since it will fail when trying to delete '.' and '..'
+  #         #
+  #         shopt -s dotglob extglob
+  #         rm -rf !(.git|gartest.txt) || true
+  #         #
+  #         if [ $(git ls-files --others | grep gartest.txt) ] ; then
+  #           echo "Uploading new RPM package"
+  #           # XXX
+  #           # # Copy the version of README from the coverage-badge branch
+  #           # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
+  #           # Add and commit all the changes we just made, so we end up committing
+  #           # just the README and the distribution package to the rpm-packages branch
+  #           git add --all
+  #           git status
+  #           # Make the commit, but it will not be saved in GitHub on the working branch
+  #           git commit -am "Uploading new RPM package"
+  #           # Push the commit to the rpm-packages branch (not to the working branch or develop)
+  #           git push -f origin ${{ github.ref }}:gar-rpm-packages
+  #         fi
 
   # Create the container we use to build the RPM
   #   This is a Centos container to match the CVP environment
   create_centos_build_container:
 
-    # XXX
-    needs: [test_git_commands]
+    # # XXX
+    # needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:
@@ -112,8 +112,8 @@ jobs:
   #   This is a minimal container with Vane and its requirements installed
   create_cvp_container:
 
-    # XXX
-    needs: [test_git_commands]
+    # # XXX
+    # needs: [test_git_commands]
 
     runs-on: ubuntu-latest
     steps:
@@ -206,11 +206,16 @@ jobs:
 
       - name: Save the tarball to the RPM branch
         run: |
-          ls -la
-          pwd
+          #
+          # Define the vane_package name
+          #
+          vane_package=${DISTRO_DIR}.tgz
+          #
+          # Set some git values
+          #
           git status || true
-          git config --local user.name actions-user
-          git config --local user.email "actions@github.com"
+          git config user.name actions-user
+          git config user.email "actions@github.com"
           #
           # List the files in the repo
           #
@@ -218,22 +223,25 @@ jobs:
           #
           # Show the current repo status
           #
-          # git status
+          git status
           #
           # Remove all the files in the repo except the .git folder,
           # the README file, and the coverage file. 'or' the command
           # to true since it will fail when trying to delete '.' and '..'
           #
           shopt -s dotglob extglob
-          rm -rf !(.git|${DISTRO_DIR}.tgz) || true
+          rm -rf !(.git|${vane_package}) || true
           #
-          if [ $(git ls-files --others | grep ${DISTRO_DIR}) ] ; then
+          # If the vane_package exists, push it to the rpm-packages branch
+          #
+          if [ $(git ls-files --others | grep ${vane_package}) ] ; then
             echo "Uploading new RPM package"
             # XXX
-            # # Copy the version of README from the coverage-badge branch
+            # Copy the version of README from the rpm-packages branch
+            #
             # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
             # Add and commit all the changes we just made, so we end up committing
-            # just the README and the coverage badge to the coverage-badge branch
+            # just the README and the RPM package to the coverage-badge branch
             git add --all
             git status
             # Make the commit, but it will not be saved in GitHub on the working branch

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -90,9 +90,9 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
+        # with:
+        #   fetch-depth: 0
 
       - name: Download the CVP Vane image file artifact we created in the previous job
         uses: actions/download-artifact@v3
@@ -149,7 +149,7 @@ jobs:
         run: |
           ls -la
           pwd
-          git status || true
+          # git status || true
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
           #
@@ -159,7 +159,7 @@ jobs:
           #
           # Show the current repo status
           #
-          git status
+          # git status
           #
           # Remove all the files in the repo except the .git folder,
           # the README file, and the coverage file. 'or' the command

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -140,36 +140,37 @@ jobs:
           tar czvf ${env.distro_dir}.tgz ${env.distro_dir}
 
       - name: Save the tarball to the RPM branch
-        git status || true
-        git config --local user.name actions-user
-        git config --local user.email "actions@github.com"
-        #
-        # List the files in the repo
-        #
-        ls -la
-        #
-        # Show the current repo status
-        #
-        git status
-        #
-        # Remove all the files in the repo except the .git folder,
-        # the README file, and the coverage file. 'or' the command
-        # to true since it will fail when trying to delete '.' and '..'
-        #
-        shopt -s dotglob extglob
-        rm -rf !(.git|${env.distro_dir}.tgz) || true
-        #
-        if [ $(git ls-files --others | grep ${env.distro_dir}.tgz ) ] ; then
-          echo "Uploading new RPM package"
-          # XXX
-          # # Copy the version of README from the coverage-badge branch
-          # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
-          # Add and commit all the changes we just made, so we end up committing
-          # just the README and the coverage badge to the coverage-badge branch
-          git add --all
+        run: |
+          git status || true
+          git config --local user.name actions-user
+          git config --local user.email "actions@github.com"
+          #
+          # List the files in the repo
+          #
+          ls -la
+          #
+          # Show the current repo status
+          #
           git status
-          # Make the commit, but it will not be saved in GitHub on the working branch
-          git commit -am "Uploading new RPM package"
-          # Push the commit to the rpm-packages branch (not to the working branch or develop)
-          git push -f origin ${{ github.ref }}:gar-rpm-packages
-        fi
+          #
+          # Remove all the files in the repo except the .git folder,
+          # the README file, and the coverage file. 'or' the command
+          # to true since it will fail when trying to delete '.' and '..'
+          #
+          shopt -s dotglob extglob
+          rm -rf !(.git|${env.distro_dir}.tgz) || true
+          #
+          if [ $(git ls-files --others | grep ${env.distro_dir}.tgz ) ] ; then
+            echo "Uploading new RPM package"
+            # XXX
+            # # Copy the version of README from the coverage-badge branch
+            # curl https://raw.githubusercontent.com/aristanetworks/vane/coverage-badge/README.md -o README.md
+            # Add and commit all the changes we just made, so we end up committing
+            # just the README and the coverage badge to the coverage-badge branch
+            git add --all
+            git status
+            # Make the commit, but it will not be saved in GitHub on the working branch
+            git commit -am "Uploading new RPM package"
+            # Push the commit to the rpm-packages branch (not to the working branch or develop)
+            git push -f origin ${{ github.ref }}:gar-rpm-packages
+          fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           ls -la
           pwd
-          # git status || true
+          git status || true
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
           #

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Build the CVP rpm package
         run: |
+          ls -la
           make rpm-cvp
 
       # - name: Copy the installation scripts into the rpms directory for packaging
@@ -146,6 +147,8 @@ jobs:
 
       - name: Save the tarball to the RPM branch
         run: |
+          ls -la
+          pwd
           git status || true
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"

--- a/Dockerfile.build-CVP
+++ b/Dockerfile.build-CVP
@@ -24,11 +24,14 @@ ENV PS1='cvp-rpm-build # '
 RUN yum install -y yum-utils epel-release centos-release-scl-rh \
 	&& yum-config-manager --enable epel
 
+# Add this repo to enable installing git236, needed for packaging operations
+RUN rpm -U https://repo.ius.io/ius-release-el7.rpm
+
 # Update yum and install the needed packages
 #   Use skip-broken to bypass errors
 RUN yum -y update --skip-broken \
   && yum -y install --skip-broken \
-    git \
+    git236 \
     make \
     python3-pip \
     rpmdevtools \

--- a/Dockerfile.build-CVP
+++ b/Dockerfile.build-CVP
@@ -24,14 +24,18 @@ ENV PS1='cvp-rpm-build # '
 RUN yum install -y yum-utils epel-release centos-release-scl-rh \
 	&& yum-config-manager --enable epel
 
-# Add this repo to enable installing git236, needed for packaging operations
-RUN rpm -U https://repo.ius.io/ius-release-el7.rpm
+# # Add this repo to enable installing git236, needed for packaging operations
+# RUN rpm -U https://repo.ius.io/ius-release-el7.rpm
+
+# Add the endpointdev repo for getting an upgraded git version
+#   https://www.endpointdev.com/blog/2021/12/installing-git-2-on-centos-7/
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
 
 # Update yum and install the needed packages
 #   Use skip-broken to bypass errors
 RUN yum -y update --skip-broken \
   && yum -y install --skip-broken \
-    git236 \
+    git \
     make \
     python3-pip \
     rpmdevtools \

--- a/Dockerfile.build-CVP
+++ b/Dockerfile.build-CVP
@@ -1,6 +1,8 @@
 # Create a container used for building CVP rpm packages for the Vane utility
 
 # Sourced in part from https://github.com/jc21/docker-rpmbuild-centos7/blob/master/docker/Dockerfile
+# and from https://github.com/teddysun/across/blob/master/docker/rpmbuild/Dockerfile.rpmbuild7
+# and from the endpointdev site mentioned below
 
 # Start with a Centos 7 distro (what CVP is deployed on)
 FROM centos:7
@@ -11,21 +13,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set the prompt
 ENV PS1='cvp-rpm-build # '
 
-# # Disable the mirrorlist because they are useless
-# RUN sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-Base.repo \
-#   && sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
-#
-# # Yum
-# RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-#   && yum localinstall -y https://yum.jc21.com/jc21-yum.rpm \
-#   && yum -y install deltarpm centos-release-scl \
-#   && yum-config-manager --enable rhel-server-rhscl-7-rpms
-
+# Initialize yum utils, epel-release and centos-release packages
 RUN yum install -y yum-utils epel-release centos-release-scl-rh \
 	&& yum-config-manager --enable epel
-
-# # Add this repo to enable installing git236, needed for packaging operations
-# RUN rpm -U https://repo.ius.io/ius-release-el7.rpm
 
 # Add the endpointdev repo for getting an upgraded git version
 #   https://www.endpointdev.com/blog/2021/12/installing-git-2-on-centos-7/

--- a/Dockerfile.build-CVP
+++ b/Dockerfile.build-CVP
@@ -11,15 +11,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set the prompt
 ENV PS1='cvp-rpm-build # '
 
-# Disable the mirrorlist because they are useless
-RUN sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-Base.repo \
-  && sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
+# # Disable the mirrorlist because they are useless
+# RUN sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-Base.repo \
+#   && sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
+#
+# # Yum
+# RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+#   && yum localinstall -y https://yum.jc21.com/jc21-yum.rpm \
+#   && yum -y install deltarpm centos-release-scl \
+#   && yum-config-manager --enable rhel-server-rhscl-7-rpms
 
-# Yum
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-  && yum localinstall -y https://yum.jc21.com/jc21-yum.rpm \
-  && yum -y install deltarpm centos-release-scl \
-  && yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum install -y yum-utils epel-release centos-release-scl-rh \
+	&& yum-config-manager --enable epel
 
 # Update yum and install the needed packages
 #   Use skip-broken to bypass errors

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -12,6 +12,7 @@ function exit_trap {
     echo -e "\n-- Vane CVP extension installed --\n"
   else
     echo -e "\n\"${last_command}\" command failed with exit code $?.\n"
+    rm -f /home/cvp/vane-cvp*.rpm
   fi
 }
 
@@ -22,7 +23,10 @@ trap exit_trap EXIT
 
 echo -e $divider
 echo -e "Install the rpm\n"
-cvpi install -f /home/cvp/vane*.rpm
+rm -f /home/cvp/vane-cvp*.rpm
+cp /root/vane-cvp*.rpm /home/cvp/
+cvpi install -f /home/cvp/vane-cvp*.rpm
+rm -f /home/cvp/vane-cvp*.rpm
 
 echo -e $divider
 echo -e "Enable the extension\n"

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -19,6 +19,9 @@ set -e
 
 divider="\n--------------------------------------------------------------\n"
 
+# Get the path to where the script is located
+script_path=$(dirname "$0")
+
 function exit_trap {
   # Check the failed command. If it was an exit command, we finished what we were doing.
   # Otherwise, log the command and the error code.
@@ -39,7 +42,7 @@ trap exit_trap EXIT
 echo -e $divider
 echo -e "Install the rpm\n"
 rm -f /home/cvp/vane-cvp*.rpm
-cp /root/vane-cvp*.rpm /home/cvp/
+cp ${script_path}/vane-cvp*.rpm /home/cvp/
 cvpi install -f /home/cvp/vane-cvp*.rpm
 rm -f /home/cvp/vane-cvp*.rpm
 

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -5,7 +5,7 @@
 # Expects the extension RPM package and this script to be located in the /root directory of the
 # CVP host, and this script should be run as the root user.
 #
-# The script will cop the RPM package to the /home/cvp directory (required by cvpi installation) and
+# The script will copy the RPM package to the /home/cvp directory (required by cvpi installation) and
 # install the RPM, enable the extension, start the extension, and display the status of the running
 # extension. After the extension is running, it disables the extension so that when CVP is stopped
 # and restarted, the extension is not loaded. This prevents any issues during CVP upgrades or other

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -29,10 +29,10 @@ cp /root/vane-cvp*.rpm /home/cvp/
 cvpi install -f /home/cvp/vane-cvp*.rpm
 rm -f /home/cvp/vane-cvp*.rpm
 
-# Enable the extension
-echo -e $divider
-echo -e "Enable the extension\n"
-cvpi enable -f vane-cvp
+# # Enable the extension
+# echo -e $divider
+# echo -e "Enable the extension\n"
+# cvpi enable -f vane-cvp
 
 # Start the extension
 echo -e $divider
@@ -44,25 +44,30 @@ echo -e $divider
 echo -e "Check the status of the extension\n"
 cvpi status -f vane-cvp
 
-# Add a cron job to uninstall the extension in 24 hours
-echo -e $divider
-echo -e "Create a cron job to uninstall the extension\n"
-#   Get the current Minute and Hour
-timestamp=$(date +"%M %H")
-#   Get the path to this file (should be /root)
-filepath=$(dirname $(realpath $0))
-#   Build the command for the cron job
-#     We need to set the BASH_ENV so the root environment is loaded properly when run
-croncmd="BASH_ENV=/root/.bash_profile $filepath/vane-cvp-uninstall.sh > $filepath/vane-cvp-uninstall.log 2>&1"
-#   Create the cronjob to run every day at this Minute and Hour
-#     It won't run now, because this minute's start point has already passed. The next instance is
-#     24 hours from now.
-cronjob="$timestamp * * * $croncmd"
-#   Add the cronjob to the crontab by echoing the crontab, removing any lines that reference the
-#   vane-cvp-uninstall.sh script, appending the new cronjob, and writing that back to the crontab.
-( crontab -l | grep -v -F "vane-cvp-uninstall.sh" ; echo "$cronjob" ) | crontab -
-#   Print the cronjob as it appears in the crontab, for reference
-crontab -l | grep -F "vane-cvp-uninstall.sh"
+# # Disable the extension so it will not start automatically on reboot
+# echo -e $divider
+# echo -e "Disable the extension\n"
+# cvpi disable -f vane-cvp
+
+# # Add a cron job to uninstall the extension in 24 hours
+# echo -e $divider
+# echo -e "Create a cron job to uninstall the extension\n"
+# #   Get the current Minute and Hour
+# timestamp=$(date +"%M %H")
+# #   Get the path to this file (should be /root)
+# filepath=$(dirname $(realpath $0))
+# #   Build the command for the cron job
+# #     We need to set the BASH_ENV so the root environment is loaded properly when run
+# croncmd="BASH_ENV=/root/.bash_profile $filepath/vane-cvp-uninstall.sh > $filepath/vane-cvp-uninstall.log 2>&1"
+# #   Create the cronjob to run every day at this Minute and Hour
+# #     It won't run now, because this minute's start point has already passed. The next instance is
+# #     24 hours from now.
+# cronjob="$timestamp * * * $croncmd"
+# #   Add the cronjob to the crontab by echoing the crontab, removing any lines that reference the
+# #   vane-cvp-uninstall.sh script, appending the new cronjob, and writing that back to the crontab.
+# ( crontab -l | grep -v -F "vane-cvp-uninstall.sh" ; echo "$cronjob" ) | crontab -
+# #   Print the cronjob as it appears in the crontab, for reference
+# crontab -l | grep -F "vane-cvp-uninstall.sh"
 
 # Print a final divider before finishing
 echo -e $divider

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -1,5 +1,19 @@
 #! /usr/bin/env bash
 
+# Installs and starts the Vane CVP extension.
+#
+# Expects the extension RPM package and this script to be located in the /root directory of the
+# CVP host, and this script should be run as the root user.
+#
+# The script will cop the RPM package to the /home/cvp directory (required by cvpi installation) and
+# install the RPM, enable the extension, start the extension, and display the status of the running
+# extension. After the extension is running, it disables the extension so that when CVP is stopped
+# and restarted, the extension is not loaded. This prevents any issues during CVP upgrades or other
+# operations.
+#
+# If the extension needs to be restarted after a stop and restart of CVP, use the associated
+# vane-cvp-start.sh script.
+
 # Exit when any command fails
 set -e
 
@@ -29,10 +43,11 @@ cp /root/vane-cvp*.rpm /home/cvp/
 cvpi install -f /home/cvp/vane-cvp*.rpm
 rm -f /home/cvp/vane-cvp*.rpm
 
-# # Enable the extension
-# echo -e $divider
-# echo -e "Enable the extension\n"
-# cvpi enable -f vane-cvp
+# Enable the extension
+#   Needs to be enabled to start the extension
+echo -e $divider
+echo -e "Enable the extension\n"
+cvpi enable -f vane-cvp
 
 # Start the extension
 echo -e $divider
@@ -44,30 +59,11 @@ echo -e $divider
 echo -e "Check the status of the extension\n"
 cvpi status -f vane-cvp
 
-# # Disable the extension so it will not start automatically on reboot
-# echo -e $divider
-# echo -e "Disable the extension\n"
-# cvpi disable -f vane-cvp
-
-# # Add a cron job to uninstall the extension in 24 hours
-# echo -e $divider
-# echo -e "Create a cron job to uninstall the extension\n"
-# #   Get the current Minute and Hour
-# timestamp=$(date +"%M %H")
-# #   Get the path to this file (should be /root)
-# filepath=$(dirname $(realpath $0))
-# #   Build the command for the cron job
-# #     We need to set the BASH_ENV so the root environment is loaded properly when run
-# croncmd="BASH_ENV=/root/.bash_profile $filepath/vane-cvp-uninstall.sh > $filepath/vane-cvp-uninstall.log 2>&1"
-# #   Create the cronjob to run every day at this Minute and Hour
-# #     It won't run now, because this minute's start point has already passed. The next instance is
-# #     24 hours from now.
-# cronjob="$timestamp * * * $croncmd"
-# #   Add the cronjob to the crontab by echoing the crontab, removing any lines that reference the
-# #   vane-cvp-uninstall.sh script, appending the new cronjob, and writing that back to the crontab.
-# ( crontab -l | grep -v -F "vane-cvp-uninstall.sh" ; echo "$cronjob" ) | crontab -
-# #   Print the cronjob as it appears in the crontab, for reference
-# crontab -l | grep -F "vane-cvp-uninstall.sh"
+# Disable the extension so it will not start automatically on reboot
+#   Once started, the extension can be disabled
+echo -e $divider
+echo -e "Disable the extension\n"
+cvpi disable -f vane-cvp
 
 # Print a final divider before finishing
 echo -e $divider

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -21,6 +21,7 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # Handle errors then exit
 trap exit_trap EXIT
 
+# Install the RPM
 echo -e $divider
 echo -e "Install the rpm\n"
 rm -f /home/cvp/vane-cvp*.rpm
@@ -28,14 +29,17 @@ cp /root/vane-cvp*.rpm /home/cvp/
 cvpi install -f /home/cvp/vane-cvp*.rpm
 rm -f /home/cvp/vane-cvp*.rpm
 
+# Enable the extension
 echo -e $divider
 echo -e "Enable the extension\n"
 cvpi enable -f vane-cvp
 
+# Start the extension
 echo -e $divider
 echo -e "Start the extension\n"
 cvpi start -f vane-cvp
 
+# Check the status of the extension
 echo -e $divider
 echo -e "Check the status of the extension\n"
 cvpi status -f vane-cvp
@@ -43,14 +47,24 @@ cvpi status -f vane-cvp
 # Add a cron job to uninstall the extension in 24 hours
 echo -e $divider
 echo -e "Create a cron job to uninstall the extension\n"
+#   Get the current Minute and Hour
 timestamp=$(date +"%M %H")
+#   Get the path to this file (should be /root)
 filepath=$(dirname $(realpath $0))
+#   Build the command for the cron job
+#     We need to set the BASH_ENV so the root environment is loaded properly when run
 croncmd="BASH_ENV=/root/.bash_profile $filepath/vane-cvp-uninstall.sh > $filepath/vane-cvp-uninstall.log 2>&1"
+#   Create the cronjob to run every day at this Minute and Hour
+#     It won't run now, because this minute's start point has already passed. The next instance is
+#     24 hours from now.
 cronjob="$timestamp * * * $croncmd"
-# The below command first deletes any existing vane-cvp-uninstall commands from the crontab, then
-# adds the cronjob to the crontab and writes it back
+#   Add the cronjob to the crontab by echoing the crontab, removing any lines that reference the
+#   vane-cvp-uninstall.sh script, appending the new cronjob, and writing that back to the crontab.
 ( crontab -l | grep -v -F "vane-cvp-uninstall.sh" ; echo "$cronjob" ) | crontab -
+#   Print the cronjob as it appears in the crontab, for reference
+crontab -l | grep -F "vane-cvp-uninstall.sh"
 
+# Print a final divider before finishing
 echo -e $divider
 
 # Exit the script

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -1,0 +1,54 @@
+#! /usr/bin/env bash
+
+# Exit when any command fails
+set -e
+
+divider="\n--------------------------------------------------------------\n"
+
+function exit_trap {
+  # Check the failed command. If it was an exit command, we finished what we were doing.
+  # Otherwise, log the command and the error code.
+  if [ "$last_command" = "exit" ]; then
+    echo -e "\n-- Vane CVP extension installed --\n"
+  else
+    echo -e "\n\"${last_command}\" command failed with exit code $?.\n"
+  fi
+}
+
+# Keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# Handle errors then exit
+trap exit_trap EXIT
+
+echo -e $divider
+echo -e "Install the rpm\n"
+cvpi install -f /home/cvp/vane*.rpm
+
+echo -e $divider
+echo -e "Enable the extension\n"
+cvpi enable -f vane-cvp
+
+echo -e $divider
+echo -e "Start the extension\n"
+cvpi start -f vane-cvp
+
+echo -e $divider
+echo -e "Check the status of the extension\n"
+cvpi status -f vane-cvp
+
+# Add a cron job to uninstall the extension in 24 hours
+echo -e $divider
+echo -e "Create a cron job to uninstall the extension\n"
+timestamp=$(date +"%M %H")
+filepath=$(dirname $(realpath $0))
+croncmd="BASH_ENV=/root/.bash_profile $filepath/vane-cvp-uninstall.sh > $filepath/vane-cvp-uninstall.log 2>&1"
+cronjob="$timestamp * * * $croncmd"
+# The below command first deletes any existing vane-cvp-uninstall commands from the crontab, then
+# adds the cronjob to the crontab and writes it back
+( crontab -l | grep -v -F "vane-cvp-uninstall.sh" ; echo "$cronjob" ) | crontab -
+
+echo -e $divider
+
+# Exit the script
+# (this triggers the exit_trap to give our final success/failure message)
+exit

--- a/resources/vane-cvp-start.sh
+++ b/resources/vane-cvp-start.sh
@@ -1,0 +1,78 @@
+#! /usr/bin/env bash
+
+# Enables and starts the Vane CVP extension. After the extension is running, disables the
+# extension so that when CVP is stopped and restarted, the extension is not loaded. This prevents
+# any issues during CVP upgrades or other operations.
+#
+# Assumes that the Vane CVP extension has been installed using the associated vane-cvp-install.sh
+# script.
+
+# Exit when any command fails
+set -e
+
+divider="\n--------------------------------------------------------------\n"
+
+function exit_trap {
+  # Check the failed command. If it was an exit command, we finished what we were doing.
+  # Otherwise, log the command and the error code.
+
+  # Set the match string for when vane-cvp is not installed
+  #   'Unknown' sometimes starts with capital, sometimes lowercase, so we just compare after the U
+  not_installed='nknown component "vane-cvp"'
+
+  # Check for conditions
+  if [ "$last_command" = "exit" ]; then
+    # If we reached the exit signal, notify the user that Vane CVP has been started
+    echo -e "\n-- Vane CVP extension started --\n"
+
+  elif [[ $result == *${not_installed}* ]]; then
+    # If the result contains the not installed string, notify the user to install Vane CVP
+    echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo -e "  Vane CVP extension is not installed"
+    echo -e "    Please run vane-cvp-install.sh"
+    echo -e "    to install the extension"
+    echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    rm -f /home/cvp/vane-cvp*.rpm
+
+  else
+    # Some other error was received, post the command and the error code for information
+    echo -e "\n\"${mycommand}\" command failed with exit code $?.\n"
+    rm -f /home/cvp/vane-cvp*.rpm
+  fi
+}
+
+# Keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# Handle errors then exit
+trap exit_trap EXIT
+
+# Enable the extension
+echo -e $divider
+echo -e "Enable the extension\n"
+mycommand="cvpi enable -f vane-cvp"
+result=$($mycommand 2>&1)
+
+# Start the extension
+echo -e $divider
+echo -e "Start the extension\n"
+mycommand="cvpi start -f vane-cvp"
+result=$($mycommand 2>&1)
+
+# Check the status of the extension
+echo -e $divider
+echo -e "Check the status of the extension\n"
+mycommand="cvpi status -f vane-cvp"
+result=$($mycommand 2>&1)
+
+# Disable the extension so it will not start automatically on reboot
+echo -e $divider
+echo -e "Disable the extension\n"
+mycommand="cvpi disable -f vane-cvp"
+result=$($mycommand 2>&1)
+
+# Print a final divider before finishing
+echo -e $divider
+
+# Exit the script
+# (this triggers the exit_trap to give our final success/failure message)
+exit

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -1,0 +1,55 @@
+#! /usr/bin/env bash
+
+# Exit when any command fails
+set -e
+
+divider="\n--------------------------------------------------------------\n"
+
+function exit_trap {
+  # Check the failed command. If it was an exit command, we finished what we were doing.
+  # Otherwise, log the command and the error code.
+  if [ "$last_command" = "exit" ]; then
+    echo -e "\n-- Vane CVP extension uninstalled --\n"
+  else
+    echo -e "\n\"${last_command}\" command failed with exit code $?.\n"
+  fi
+}
+
+# Keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# Handle errors then exit
+trap exit_trap EXIT
+
+echo -e $divider
+echo -e "Remove the container images\n"
+# Remove the container images first
+#  - If the uninstallation fails for some reason, at least the containers are removed
+#  - If the containers do not exist, the commands do not fail and the uninstallation will
+#    still proceed afterwards
+img_id=`nerdctl images | grep vane-cvp | awk '{print $3}'`
+nerdctl rmi -f vane-cvp
+if [ ! -z ${img_id:+x} ]; then
+  nerdctl rmi -f ${img_id}
+fi
+
+echo -e $divider
+echo -e "Stop the extension\n"
+cvpi stop -f vane-cvp
+
+echo -e $divider
+echo -e "Disable the extension\n"
+cvpi disable -f vane-cvp
+
+echo -e $divider
+echo -e "Uninstall the extension\n"
+cvpi uninstall -f vane-cvp
+
+# Remove the cron job from the crontab
+echo -e $divider
+echo -e "Remove the cron job from the crontab\n"
+croncmd=$(realpath $0)
+( crontab -l | grep -v -F "$croncmd" ) | crontab -
+
+# Exit the script
+# (this triggers the exit_trap to give our final success/failure message)
+exit

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -20,26 +20,29 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # Handle errors then exit
 trap exit_trap EXIT
 
-echo -e $divider
-echo -e "Remove the container images\n"
 # Remove the container images first
 #  - If the uninstallation fails for some reason, at least the containers are removed
 #  - If the containers do not exist, the commands do not fail and the uninstallation will
 #    still proceed afterwards
+echo -e $divider
+echo -e "Remove the container images\n"
 img_id=`nerdctl images | grep vane-cvp | awk '{print $3}'`
 nerdctl rmi -f vane-cvp
 if [ ! -z ${img_id:+x} ]; then
   nerdctl rmi -f ${img_id}
 fi
 
+# Stop the extension
 echo -e $divider
 echo -e "Stop the extension\n"
 cvpi stop -f vane-cvp
 
+# Disable the extension
 echo -e $divider
 echo -e "Disable the extension\n"
 cvpi disable -f vane-cvp
 
+# Uninstall the extension
 echo -e $divider
 echo -e "Uninstall the extension\n"
 cvpi uninstall -f vane-cvp
@@ -49,6 +52,9 @@ echo -e $divider
 echo -e "Remove the cron job from the crontab\n"
 croncmd=$(realpath $0)
 ( crontab -l | grep -v -F "$croncmd" ) | crontab -
+
+# Print a final divider before finishing
+echo -e $divider
 
 # Exit the script
 # (this triggers the exit_trap to give our final success/failure message)

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -1,5 +1,11 @@
 #! /usr/bin/env bash
 
+# Uninstalls the Vane CVP extension from CVP
+#
+# This script will remove any container images associated with the Vane CVP extension, then stop
+# and disable the vane-cvp extension and uninstall the extension from CVP, which should remove
+# the copied RPM package from the /data/apprpms directory.
+
 # Exit when any command fails
 set -e
 
@@ -8,10 +14,22 @@ divider="\n--------------------------------------------------------------\n"
 function exit_trap {
   # Check the failed command. If it was an exit command, we finished what we were doing.
   # Otherwise, log the command and the error code.
+
+  # Set the match string for when vane-cvp is not installed
+  #   'Unknown' sometimes starts with capital, sometimes lowercase, so we just compare after the U
+  not_installed='nknown component "vane-cvp"'
+
   if [ "$last_command" = "exit" ]; then
+    # If we reached the exit signal, notify the user that Vane CVP has been started
     echo -e "\n-- Vane CVP extension uninstalled --\n"
+
+  elif [[ $result == *${not_installed}* ]]; then
+    # If the result contains the not installed string, notify the user that Vane CVP is
+    # already uninstalled
+    echo -e "Vane CVP extension has already been uninstalled, no further steps necessary"
+
   else
-    echo -e "\n\"${last_command}\" command failed with exit code $?.\n"
+    echo -e "\n\"${mycommand}\" command failed with exit code $?.\n"
   fi
 }
 
@@ -35,23 +53,20 @@ fi
 # Stop the extension
 echo -e $divider
 echo -e "Stop the extension\n"
-cvpi stop -f vane-cvp
+mycommand="cvpi stop -f vane-cvp"
+result=$($mycommand 2>&1)
 
 # Disable the extension
 echo -e $divider
 echo -e "Disable the extension\n"
-cvpi disable -f vane-cvp
+mycommand="cvpi disable -f vane-cvp"
+result=$($mycommand 2>&1)
 
 # Uninstall the extension
 echo -e $divider
 echo -e "Uninstall the extension\n"
-cvpi uninstall -f vane-cvp
-
-# Remove the cron job from the crontab
-echo -e $divider
-echo -e "Remove the cron job from the crontab\n"
-croncmd=$(realpath $0)
-( crontab -l | grep -v -F "$croncmd" ) | crontab -
+mycommand="cvpi uninstall -f vane-cvp"
+result=$($mycommand 2>&1)
 
 # Print a final divider before finishing
 echo -e $divider

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -26,7 +26,7 @@ function exit_trap {
   elif [[ $result == *${not_installed}* ]]; then
     # If the result contains the not installed string, notify the user that Vane CVP is
     # already uninstalled
-    echo -e "Vane CVP extension has already been uninstalled, no further steps necessary"
+    echo -e "Vane CVP extension is not installed, no further steps necessary"
 
   else
     echo -e "\n\"${mycommand}\" command failed with exit code $?.\n"


### PR DESCRIPTION
# Please include a summary of the changes

These changes address installation and uninstallation difficulties with the Vane CVP extension, simplifying the process for the user. The zip file that is downloaded from the Vane repository now contains a directory that includes the Vane RPM package, plus 3 shell scripts that are used for handling the Vane CVP extension. 

The user simply needs to download the zip file and copy it to the CVP host in the root user's home directory (for simplicity), then log into the host as root user and run the command
    `unzip vane-cvp-<version>-rpm.zip && tar xzvf vane-cvp*.tgz`
to extract the contents. After that, a directory will have been created containing the RPM and the 3 shell scripts.

Within the directory, running `./vane-cvp-install.sh` will install the Vane CVP extension, start it running, and after it is running will disable the extension. The reason for disabling the extension after running has to do with the possible interference with CVP upgrades - some reports have indicated that disabling the extension will help prevent this interference.

The extension will continue running even after being disabled. If the host is stopped, or a `cvpi stop all` command is issued, the extension will stop and not restart. At this point, running `./vane-cvp-start.sh` will restart the extension, then after it is running, disable it again, just as with the installation proceedure.

Running `./vane-cvp-uninstall.sh` will disable the extension (in case it had been manually enabled), stop the extension, uninstall the extension, and remove the associated containers from the CVP host. This is useful for when an update to the Vane extension needs to be performed or the extension is no longer needed.

- .github/workflows/cvp-extension-builder.yml (updated)
  - updated the workflow to include the installation scripts in the package and to name the package
    according to the Vane version in the pyproject file
- Dockerfile.build-CVP (updated)
  - updated the dockerfile for the RPM build container to be able to install a later version of git
    and to avoid some failures in the build process
- installation scripts (new files)
  - resources/vane-cvp-install.sh - installs vane-cvp for the user, then disables the extension
    (does not stop the extension)
  - resources/vane-cvp-start.sh - starts vane-cvp for the user, assuming the extension is installed,
    and has been stopped by a CVP stop or host shutdown
  - resources/vane-cvp-uninstall.sh - uninstalls vane-cvp for the user, removing the extension and
    the associated containers


# Any specific logic/part of code you need extra attention on

Please pay close attention to the 3 shell scripts that take care of the installation, starting the extension, and uninstall the extension. Make any comments or suggestions regarding anything that is not clear.

# Include the Issue number and link

No related issue

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [ ] Easy
- - [X] Medium
- - [ ] Hard 

# How Has This Been Tested?

Extracting the archive
<img width="636" alt="Screenshot 2023-10-19 at 4 55 50 PM" src="https://github.com/aristanetworks/vane/assets/13952603/c5db184f-a7e5-4a39-8e4f-1672e01e9934">

---
List the contents of the extracted directory
<img width="571" alt="Screenshot 2023-10-19 at 4 56 05 PM" src="https://github.com/aristanetworks/vane/assets/13952603/7ea3b7e0-448d-4e5c-a2a3-13ad23462419">

---
Install the extension
<img width="708" alt="Screenshot 2023-10-19 at 4 58 41 PM" src="https://github.com/aristanetworks/vane/assets/13952603/8b3b75b5-af1d-461a-a89b-e98e259086b4">
<img width="976" alt="Screenshot 2023-10-19 at 4 59 08 PM" src="https://github.com/aristanetworks/vane/assets/13952603/4258caa3-c583-4408-bf1e-b4463c7d8f17">
<img width="863" alt="Screenshot 2023-10-19 at 5 00 52 PM" src="https://github.com/aristanetworks/vane/assets/13952603/82139398-733d-4c71-9ee7-d099f770788b">

---
Uninstall the extension
<img width="649" alt="Screenshot 2023-10-19 at 5 02 01 PM" src="https://github.com/aristanetworks/vane/assets/13952603/86a8b182-d0ca-442d-9626-ef145947f3a8">

---
Try to start the extension when the extension has been uninstalled
<img width="582" alt="Screenshot 2023-10-19 at 5 02 18 PM" src="https://github.com/aristanetworks/vane/assets/13952603/2a2ad1d0-aee4-4152-a6ce-1169b6820b09">


## New feature

Manual testing



# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
Mostly files related to pipeline changes
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
