### PR TITLE
[FIX]: for bug involving incorrect skip condition check in docx reports

### DIFF
--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -1182,13 +1182,14 @@ class ReportClient:
                 for dut in test_case["duts"]:
                     suite_result["total_tests"] += 1
 
-                    if dut["test_result"] and dut["test_result"] == "Skipped":
+                    if dut["skip"]:
                         suite_result["total_skip"] += 1
                         dut["fail_or_skip_reason"] = dut.get("actual_output", "")
-                    elif dut["test_result"] and dut["test_result"] != "Skipped":
+                    elif dut["test_result"]:
                         suite_result["total_pass"] += 1
                     else:
                         suite_result["total_fail"] += 1
+
 
             logging.debug(f"Compiled test suite data: {suite_result}")
             suite_results.append(suite_result)
@@ -1224,10 +1225,10 @@ class ReportClient:
                     logging.debug(f"Compiling results for DUT/s {dut_name}")
                     testcase_id = dut["test_id"]
 
-                    if dut["test_result"] and dut["test_result"] == "Skipped":
+                    if dut["skip"]:
                         test_result = "SKIP"
                         fail_reason = dut.get("actual_output", "")
-                    elif dut["test_result"] and dut["test_result"] != "Skipped":
+                    elif dut["test_result"]:
                         test_result = "PASS"
                     else:
                         test_result = "FAIL"

--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -1190,7 +1190,6 @@ class ReportClient:
                     else:
                         suite_result["total_fail"] += 1
 
-
             logging.debug(f"Compiled test suite data: {suite_result}")
             suite_results.append(suite_result)
 


### PR DESCRIPTION


# Please include a summary of the changes

* report_client.py: Changed the logic that checked for skip condition while counting # of skipped. We were using dut["testcase_result"] which actually is a boolean value and would be set to False for both a failed and skipped test case. Changed the logic to use dut["skip"] and dut[testcase_result"] field instead.

# Any specific logic/part of code you need extra attention on

@kgrozis-arista I went through the different methods to make sure our checks for SKIP are correct, I think these 2 places got missed in the original PR, but should be good now. Can you also double check for any other place that we may have missed so there are no hidden bugs anymore :) 

# Include the Issue number and link

#584 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix


   
<img width="712" alt="Screenshot 2023-10-23 at 3 15 31 PM" src="https://github.com/aristanetworks/vane/assets/123415500/6c817e2e-8b96-4019-b18b-34853df9d9e4">

 Ran with customised test case report summary (1) and default test case report summary (2):

<img width="731" alt="Screenshot 2023-10-23 at 3 15 18 PM" src="https://github.com/aristanetworks/vane/assets/123415500/8387b7e3-8477-4d93-a529-6c2aaf5c39ca">

   
<img width="713" alt="Screenshot 2023-10-23 at 3 15 07 PM" src="https://github.com/aristanetworks/vane/assets/123415500/d896cbcf-9554-426f-a28e-917407090dab">

    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure