### PR TITLE
Simplified the Installation script to error out if requirements are not installed

### DIFF
--- a/install_vane.sh
+++ b/install_vane.sh
@@ -20,6 +20,10 @@ fi
 DEFAULT+="vane"
 DESTINATION_FOLDER+=$DEFAULT
 
+function remove_vane() {
+    echo -e  "${yellow}Enter yes below to remove the cloned vane repo${default}"
+    rm -r $DESTINATION_FOLDER
+}
 
 # (1) Check if Git is installed
 if command -v git &>/dev/null; then
@@ -46,6 +50,7 @@ if command -v python3.9 &>/dev/null; then
     echo -e  "${green}Python 3.9 is installed.${default}"
 else
     echo -e  "${red}Python 3.9 is not installed. Install Python 3.9 before running the script${default}"
+    remove_vane
     exit 1
 fi
 
@@ -61,6 +66,7 @@ else
         echo -e "${green}Curl is installed on your system.${default}"
     else
         echo -e  "${red}Curl is not installed. Install Curl before running the script in order to be able to install Poetry.${default}"
+        remove_vane
         exit 1  # Exit the script with a non-zero status
         # fi
     fi
@@ -71,6 +77,7 @@ else
         echo -e  "${green}Poetry installed successfully by curling installation script.${default}"
     else
         echo -e  "${red}Failed to install Poetry. Exiting script.${default}"
+        remove_vane
         exit 1  # Exit the script with a non-zero status
     fi
     current_user=$(whoami)
@@ -98,6 +105,7 @@ if [ $? -eq 0 ]; then
         echo -e  "${green}Python version set correctly for vane's virtual environment.${default}"
     else
         echo -e  "${red}Failed to set Python version for virtual environment correctly. Exiting script${default}"
+        remove_vane
         exit 1  # Exit the script with a non-zero status
 fi
 echo -e  "${green}Activating the poetry virtual environment${default}"

--- a/install_vane.sh
+++ b/install_vane.sh
@@ -2,7 +2,7 @@
 
 # Declare global variables
 
-# initialising variables for color formatting messages
+# Initialising variables for color formatting messages
 
 default="\e[0m"
 yellow="\e[33m"
@@ -20,75 +20,16 @@ fi
 DEFAULT+="vane"
 DESTINATION_FOLDER+=$DEFAULT
 
-PACKAGE_MANAGER=""
-PYTHON_VERSION="3.9"
-INSTALL_OPTION=""
 
-# Function to install Homebrew (macOS) if not already installed
-function install_homebrew() {
-    echo -e  "${yellow}Installing Homebrew...${default}"
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-}
-
-# Function to setup package manager to be used to install commands needed
-function set_up_package_manager() {
-
-    # Determine the package manager based on the system's OS and implement initial configuration
-
-    # Debian based Linux distribution
-    if command -v apt-get &>/dev/null; then
-        echo -e  "${yellow}Using apt-get as found Linux Subsystem${default}"
-        PACKAGE_MANAGER="apt-get"
-        INSTALL_OPTION="-y"
-        apt update
-    # CentOS and older versions
-    elif command -v yum &>/dev/null; then
-        echo -e  "${yellow}Using yum as found CentOS${default}"
-        PACKAGE_MANAGER="yum"
-        INSTALL_OPTION="-y"
-        path=$(pwd)
-        cd /etc/yum.repos.d/
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        cd "$path"
-        yum install -y glibc-langpack-en
-    # For MacOs
-    elif command -v brew &>/dev/null; then
-        echo -e  "${yellow}Using brew as found MacOS${default}"
-        PACKAGE_MANAGER="brew"
-        INSTALL_OPTION="--force"
-    else
-	    # Install Homebrew on macOS
-    	if [[ "$OSTYPE" =~ ^darwin ]]; then
-            install_homebrew
-	        PACKAGE_MANAGER="brew"
-            INSTALL_OPTION="--force"
-	    else
-            # Add support for other package managers if needed, like chocolatey for Windows
-            echo -e  "${red}Error: Package manager not found."
-            exit 1
-        fi
-    fi
-}
-
-# (1) Set up package manager
-set_up_package_manager
-
-# (2) Check if Git is installed
+# (1) Check if Git is installed
 if command -v git &>/dev/null; then
-    echo -e  "${yellow}Git is installed.${default}"
+    echo -e  "${green}Git is installed.${default}"
 else
-    echo -e  "${yellow}Git is not installed. Installing Git${default}"
-    $PACKAGE_MANAGER install $INSTALL_OPTION git
-    if [ $? -eq 0 ]; then
-        echo -e  "${green}Git installed successfully.${default}"
-    else
-        echo -e  "${red}Failed to install git. Exiting script.${default}"
-        exit 1  # Exit the script with a non-zero status
-    fi
+    echo -e  "${red}Git is not installed. Install Git before running the script${default}"
+    exit 1
 fi
 
-# (3) Download Vane repo into current directory
+# (2) Download Vane repo into current directory
 echo -e  "${yellow}Cloning Vane Repo${default}"
 git clone https://github.com/aristanetworks/vane.git $DESTINATION_FOLDER
 
@@ -100,69 +41,68 @@ else
     exit 1  # Exit the script with a non-zero status
 fi
 
-# (4) Install Python 3.9 if version does not exist
-if ! command -v python3.9 &>/dev/null; then
-    echo -e  "${yellow}Python 3.9 not found. Installing Python 3.9${default}"
-    if [ "$PACKAGE_MANAGER" = "brew" ]; then
-        brew install $INSTALL_OPTION python@3.9
-    elif [ "$PACKAGE_MANAGER" = "apt-get" ]; then
-        apt install $INSTALL_OPTION software-properties-common
-        add-apt-repository $INSTALL_OPTION ppa:deadsnakes/ppa
-        apt install $INSTALL_OPTION python3.9
-        apt-get install $INSTALL_OPTION python3-pip
-    else
-        $PACKAGE_MANAGER install $INSTALL_OPTION python3.9
-    fi
-    if [ $? -eq 0 ]; then
-        echo -e  "${green}Python3.9 installed successfully.${default}"
-    else
-        echo -e  "${red}Failed to install Python3.9. Exiting script.${default}"
-        exit 1  # Exit the script with a non-zero status
-    fi
-
+# (3) Check if Python 3.9 version exists
+if command -v python3.9 &>/dev/null; then
+    echo -e  "${green}Python 3.9 is installed.${default}"
 else
-    echo -e  "${yellow}Python 3.9 is already installed.${default}"
+    echo -e  "${red}Python 3.9 is not installed. Install Python 3.9 before running the script${default}"
+    exit 1
 fi
 
-# (5) Check if Poetry is installed using pip3
-if pip3 show poetry &>/dev/null; then
-    echo -e  "${yellow}Poetry is already installed.${default}"
+# (4) Check if Poetry is installed
+if poetry --version &>/dev/null; then
+    echo -e  "${green}Poetry is installed.${default}"
+    poetry="poetry"
 else
-    echo -e  "${yellow}Poetry is not installed. Installing Poetry 1.4.2 via pipx${default}"
-    if command -v pipx &> /dev/null; then
-        echo -e  "${yellow}pipx is already installed${default}"
+    echo -e  "${yellow}Poetry is not installed. Installing Poetry via curling of installation script${default}"
+    # Check if curl exists on the system
+    echo -e  "${yellow}Checking for Curl on the system...${default}"
+    if command -v curl &> /dev/null; then
+        echo -e "${green}Curl is installed on your system.${default}"
     else
-        echo -e  "${yellow}pipx is not installed. Installing pipx via pip${default}"
-        python3 -m pip install --user pipx
-        if [ $? -eq 0 ]; then
-            echo -e  "${green}pipx installed successfully.${default}"
-        else
-            echo -e  "${red}Failed to install pipx. Exiting script.${default}"
-            exit 1  # Exit the script with a non-zero status
-        fi
+        echo -e  "${red}Curl is not installed. Install Curl before running the script in order to be able to install Poetry.${default}"
+        exit 1  # Exit the script with a non-zero status
+        # fi
     fi
-    echo -e "${yellow}Adding pipx to PATH environment variable${default}"
-    python3 -m pipx ensurepath
-    pipx install poetry==1.4.2
-    # Error handling in case poetry is not installed correctly
+    # Install poetry
+    curl -sSL https://install.python-poetry.org | python3.9 -
+    # Check if installation of poetry was succesfull
     if [ $? -eq 0 ]; then
-        echo -e  "${green}Poetry installed successfully.${default}"
+        echo -e  "${green}Poetry installed successfully by curling installation script.${default}"
     else
         echo -e  "${red}Failed to install Poetry. Exiting script.${default}"
         exit 1  # Exit the script with a non-zero status
     fi
+    current_user=$(whoami)
+    # Initialise the path of poetry bin (where poetry got installed)
+    # depending on the user
+    if [ "$current_user" == "root" ]; then
+        poetry="/root/.local/bin/poetry"
+        echo -e  "${green}Invoking Poetry using ${poetry}.${default}"
+    else
+        poetry="/home/${current_user}/.local/bin/poetry"
+        echo -e  "${green}Invoking Poetry using ${poetry}.${default}"
+    fi
 fi
 
-# (6) Set up virtual environment in downloaded vane folder
-cd $DESTINATION_FOLDER
-echo -e  "${yellow}cd $DESTINATION_FOLDER${default}"
-path=$(pwd)
-poetry config virtualenvs.path "$path"
-python=$(command -v python3.9)
-poetry env use "$python"
-echo -e  "${green}Activating the poetry virtual environment${default}"
-poetry install 
+# (5) Set up virtual environment in downloaded vane folder
 
-# (7) Activate poetry environment within the root folder
+cd $DESTINATION_FOLDER
+echo -e  "${yellow}Entering $DESTINATION_FOLDER folder${default}"
+path=$(pwd)
+$poetry config virtualenvs.path "$path"
+python=$(command -v python3.9)
+$poetry env use "$python"
+# Check if python virtual environment got created with correct version
+if [ $? -eq 0 ]; then
+        echo -e  "${green}Python version set correctly for vane's virtual environment.${default}"
+    else
+        echo -e  "${red}Failed to set Python version for virtual environment correctly. Exiting script${default}"
+        exit 1  # Exit the script with a non-zero status
+fi
+echo -e  "${green}Activating the poetry virtual environment${default}"
+$poetry install 
+
+# (6) Activate poetry environment within the root folder
 echo -e  "${green}Entering the poetry virtual environment${default}"
-poetry shell
+$poetry shell

--- a/install_vane.sh
+++ b/install_vane.sh
@@ -20,10 +20,6 @@ fi
 DEFAULT+="vane"
 DESTINATION_FOLDER+=$DEFAULT
 
-function remove_vane() {
-    echo -e  "${yellow}Enter yes below to remove the cloned vane repo${default}"
-    rm -r $DESTINATION_FOLDER
-}
 
 # (1) Check if Git is installed
 if command -v git &>/dev/null; then
@@ -50,7 +46,6 @@ if command -v python3.9 &>/dev/null; then
     echo -e  "${green}Python 3.9 is installed.${default}"
 else
     echo -e  "${red}Python 3.9 is not installed. Install Python 3.9 before running the script${default}"
-    remove_vane
     exit 1
 fi
 
@@ -66,7 +61,6 @@ else
         echo -e "${green}Curl is installed on your system.${default}"
     else
         echo -e  "${red}Curl is not installed. Install Curl before running the script in order to be able to install Poetry.${default}"
-        remove_vane
         exit 1  # Exit the script with a non-zero status
         # fi
     fi
@@ -77,7 +71,6 @@ else
         echo -e  "${green}Poetry installed successfully by curling installation script.${default}"
     else
         echo -e  "${red}Failed to install Poetry. Exiting script.${default}"
-        remove_vane
         exit 1  # Exit the script with a non-zero status
     fi
     current_user=$(whoami)
@@ -105,7 +98,6 @@ if [ $? -eq 0 ]; then
         echo -e  "${green}Python version set correctly for vane's virtual environment.${default}"
     else
         echo -e  "${red}Failed to set Python version for virtual environment correctly. Exiting script${default}"
-        remove_vane
         exit 1  # Exit the script with a non-zero status
 fi
 echo -e  "${green}Activating the poetry virtual environment${default}"

--- a/install_vane.sh
+++ b/install_vane.sh
@@ -59,7 +59,7 @@ if poetry --version &>/dev/null; then
     echo -e  "${green}Poetry is installed.${default}"
     poetry="poetry"
 else
-    echo -e  "${yellow}Poetry is not installed. Installing Poetry via curling of installation script${default}"
+    echo -e  "${yellow}Checking for Poetry installation. Installing Poetry via curling of installation script if needed${default}"
     # Check if curl exists on the system
     echo -e  "${yellow}Checking for Curl on the system...${default}"
     if command -v curl &> /dev/null; then
@@ -74,7 +74,7 @@ else
     curl -sSL https://install.python-poetry.org | python3.9 -
     # Check if installation of poetry was succesfull
     if [ $? -eq 0 ]; then
-        echo -e  "${green}Poetry installed successfully by curling installation script.${default}"
+        echo -e  "${green}Poetry has been installed successfully by curling installation script.${default}"
     else
         echo -e  "${red}Failed to install Poetry. Exiting script.${default}"
         remove_vane


### PR DESCRIPTION

# Please include a summary of the changes

* install_vane.sh: removed logic which tried installing requirements, now script errors out and asks the user to install those before trying to setup Vane. Installation of poetry is done using curl.

# Any specific logic/part of code you need extra attention on

Installation of poetry: Point (4) : https://github.com/aristanetworks/vane/blob/a361ee9d37bfe023e668f4d5af86994b8354d2c3/install_vane.sh#L57

# Include the Issue number and link

#588 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other : Refactoring of logic to handle permission issues & installation of poetry logic changed

# Effort required on reviewers end

- - [ ] Easy
- - [X] Medium
- - [ ] Hard 

# How Has This Been Tested?

Tested on Ubuntu, CentOs docker images
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  