### PR TITLE
Refactored vxlan_interfaces to vxlan_interface in gen_configs_from_avd

### DIFF
--- a/vane/gen_configs_from_avd.py
+++ b/vane/gen_configs_from_avd.py
@@ -69,7 +69,7 @@ def create_configs_file(avd_sd_dir):
             config[device_name]["ethernet_interfaces"] = full_config.get("ethernet_interfaces", {})
             config[device_name]["mlag_configuration"] = full_config.get("mlag_configuration", {})
             config[device_name]["loopback_interfaces"] = full_config.get("loopback_interfaces", {})
-            config[device_name]["vxlan_interfaces"] = full_config.get("vxlan_interfaces", {})
+            config[device_name]["vxlan_interface"] = full_config.get("vxlan_interface", {})
             add_lldp_neighbors_dict(config)
     with open("configs.yml", "w", encoding="utf-8") as file:
         yaml.safe_dump(config, file, sort_keys=False)


### PR DESCRIPTION
# Please include a summary of the changes

* gen_configs_from_avd.py: avd config info did not have a field called vxlan_interfaces but instead vxlan_interface



# Include the Issue number and link

#203 



# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix
@shachiagarwal has tested with the change in the customer environment
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
 