### PR TITLE
Omitting show clock when show_cmds being run via run_show_cmds has a show clock

### DIFF
--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -930,6 +930,20 @@ def create_duts_file(topology_file, inventory_file):
     return None
 
 
+def post_process_skip(tops, steps, output=""):
+    """Post processing for test case that encounters a PyTest Skip
+
+    Args:
+        tops(obj): Test case object
+        steps(func): Test case
+        output(str): Test case show output
+    """
+
+    tops.skip = True
+    tops.parse_test_steps(steps)
+    tops.generate_report(tops.dut_name, output)
+
+
 # pylint: disable-next=too-many-instance-attributes
 class TestOps:
     """Common testcase operations and variables"""
@@ -1391,7 +1405,7 @@ class TestOps:
         self.set_evidence_default(dut_name)
 
         # first run show clock if flag is set
-        if self.show_clock_flag:
+        if self.show_clock_flag and "show clock" not in cmds:
             show_clock_cmds = ["show clock"]
             # run the show_clock_cmds
             try:
@@ -1610,17 +1624,3 @@ class TestOps:
 
             else:
                 logging.info("No Session to clear")
-
-
-def post_process_skip(tops, steps, output=""):
-    """Post processing for test case that encounters a PyTest Skip
-
-    Args:
-        tops(obj): Test case object
-        steps(func): Test case
-        output(str): Test case show output
-    """
-
-    tops.skip = True
-    tops.parse_test_steps(steps)
-    tops.generate_report(tops.dut_name, output)


### PR DESCRIPTION


# Please include a summary of the changes

* tests_tools.py:
(1) check for show clock in show_cmds before running it
(2) refactored post_process_skip to be before TestOps for readability since it is not a TestOps operation, unless we want to include it in TestOps

# Any specific logic/part of code you need extra attention on

Was the original intention to make post_process_skip a TestOps method, from the positioning it seemed like that, but its use and indentation suggested otherwise

https://github.com/aristanetworks/vane/blob/c08bc1ab25b211b8c369fc11a799f0f1b33da5eb/vane/tests_tools.py#L933


# Include the Issue number and link

#526 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other: Refactoring and logic change to better match expected functionality

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

Reports omit "show clock" if show clock is already in list of commands to be run
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
