### PR TITLE
Added test id to sample network tests

### DIFF
--- a/sample_network_tests/aaa/test_definition.yaml
+++ b/sample_network_tests/aaa/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_aaa.py
   testcases:
     - name: test_if_authentication_counters_are_incrementing_on_
+      test_id: TN1.1
       description: Verify AAA counters are working correctly
       show_cmd: show aaa counters
       expected_output: null
@@ -13,6 +14,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_aaa_session_logging_is_working_on_
+      test_id: TN1.2
       description: Verify AAA session logging is working by identifying eapi connection
       show_cmd: show users detail
       expected_output: command-api
@@ -25,6 +27,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_commands_authorization_methods_set_on_
+      test_id: TN1.3
       description: Verify AAA command authorization are method-lists set correct
       show_cmd: show aaa methods all
       # List command authorizations to check on DUT
@@ -39,6 +42,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_exec_authorization_methods_set_on_
+      test_id: TN1.4
       description: Verify AAA exec authorization are method-lists set correct
       show_cmd: show aaa methods all
       # List exec authorizations to check on DUT
@@ -53,6 +57,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_default_login_authentication_methods_set_on_
+      test_id: TN1.5
       description: Verify AAA default login authentication are method-lists set correct
       show_cmd: show aaa methods all
       # List default login authentication to check on DUT
@@ -67,6 +72,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_login_authentication_methods_set_on_
+      test_id: TN1.6
       description: AAA login authentication are method-lists set correct
       show_cmd: show aaa methods all
       # List login authentication to check on DUT
@@ -80,6 +86,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_dot1x_authentication_methods_set_on_
+      test_id: TN1.7
       description: Verify AAA dot1x authentication are method-lists set correct
       show_cmd: show aaa methods all
       # List dot1x authentication to check on DUT
@@ -93,6 +100,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_enable_authentication_methods_set_on_
+      test_id: TN1.8
       description: Verify AAA enable authentication are method-lists set correct
       show_cmd: show aaa methods all
       # List enable login authentication to check on DUT
@@ -108,6 +116,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_system_accounting_methods_set_on_
+      test_id: TN1.9
       description: Verify AAA system accounting method-lists are set correct
       # List default system accounting to check on DUT
       default_acct: []
@@ -123,6 +132,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_exec_accounting_methods_set_on_
+      test_id: TN1.10
       description: Verify AAA exec accounting method-lists are set correct
       # List exec system accounting to check on DUT
       default_acct: []
@@ -138,6 +148,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_privilege_accounting_methods_set_on_
+      test_id: TN1.11
       description: Verify AAA privilege accounting method-lists are set correct
       # List privilege system accounting to check on DUT
       default_acct: []
@@ -153,6 +164,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_dot1x_accounting_methods_set_on_
+      test_id: TN1.12
       description: Verify AAA dot1x accounting method-lists are set correct
       # List dot1x system accounting to check on DUT
       default_acct: []

--- a/sample_network_tests/api/test_definition.yaml
+++ b/sample_network_tests/api/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_api.py
   testcases:
     - name: test_if_management_https_api_server_is_running_on_
+      test_id: TN2.1
       description: Verify management api https server is running
       show_cmd: show management api http-commands
       # If HTTPS API server is running
@@ -15,6 +16,7 @@
         - DLFW4
 
     - name: test_if_management_https_api_server_port_is_correct_on_
+      test_id: TN2.2
       description: Verify https server is enabled on port 443
       show_cmd: show management api http-commands
       # HTTPS API server port number
@@ -29,6 +31,7 @@
         - DLFW4
 
     - name: test_if_management_https_api_server_is_enabled_on_
+      test_id: TN2.3
       description: Verify management api https server is enabled
       show_cmd: show management api http-commands
       # If HTTPS API server is enabled
@@ -43,6 +46,7 @@
         - DLFW4
 
     - name: test_if_management_http_api_server_is_running_on_
+      test_id: TN2.4
       description: Verify management api http server is not running
       show_cmd: show management api http-commands
       # If HTTP API server is running
@@ -57,6 +61,7 @@
         - DLFW4
 
     - name: test_if_management_local_http_api_server_is_running_on_
+      test_id: TN2.5
       description: Verify management api local httpserver is not running
       show_cmd: show management api http-commands
       # If Local HTTP API server is running

--- a/sample_network_tests/cpu/test_definition.yaml
+++ b/sample_network_tests/cpu/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_cpu.py
   testcases:
     - name: test_1_sec_cpu_utlization_on_
+      test_id: TN3.1
       description: Verify 1 second CPU % is under specificied value
       show_cmd: show processes
       # CPU process ceiling
@@ -15,6 +16,7 @@
         - DLFW4
 
     - name: test_1_min_cpu_utlization_on_
+      test_id: TN3.2
       description: Verify 1 minute CPU % is under specificied value
       show_cmd: show processes
       # CPU process ceiling
@@ -29,6 +31,7 @@
         - DLFW4
 
     - name: test_5_min_cpu_utlization_on_
+      test_id: TN3.3
       description: Verify 5 minute CPU % is under specificied value
       show_cmd: show processes
       # CPU process ceiling

--- a/sample_network_tests/daemon/test_definition.yaml
+++ b/sample_network_tests/daemon/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_daemon.py
   testcases:
     - name: test_if_daemons_are_running_on_
+      test_id: TN4.1
       description: Verify a list of daemons are running on DUT
       show_cmd: show daemon
       # List daemons to check on DUT
@@ -17,6 +18,7 @@
         - DLFW4
 
     - name: test_if_daemons_are_enabled_on_
+      test_id: TN4.2
       description: Verify a list of daemons are enabled on DUT
       # List daemons to check on DUT
       daemons:

--- a/sample_network_tests/dns/test_definition.yaml
+++ b/sample_network_tests/dns/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_dns.py
   testcases:
     - name: test_if_dns_resolves_on_
+      test_id: TN5.1
       description: Verify DNS is running by performing pings and verifying name resolution
       show_cmd: null
       # List of URLs to test DNS against
@@ -17,6 +18,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_dns_servers_are_reachable_on_
+      test_id: TN5.2
       description: Verifies DNS servers are reachable via ping
       show_cmd: null
       dns_servers:
@@ -32,6 +34,7 @@
         - DSR01
         - DCBBW1
     - name: test_dns_configuration_on_
+      test_id: TN5.3
       description: Verifies DNS configuration matches the recommended practices 
       show_cmd: show running-config section name-server
       # List of NTP servers

--- a/sample_network_tests/environment/test_definition.yaml
+++ b/sample_network_tests/environment/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_environment.py
   testcases:
     - name: test_if_system_environment_temp_is_in_spec_on_
+      test_id: TN6.1
       description: Verify system temperature environmentals are functional within spec
       # Expected system temperature
       expected_output: temperatureOk
@@ -13,6 +14,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_sensors_temp_is_in_spec_on_
+      test_id: TN6.2
       description: Verify system temperature sensors environmentals are functional within spec
       # Expected system temperature
       expected_output: False
@@ -25,6 +27,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_system_environment_power_are_in_spec_on_
+      test_id: TN6.3
       description: Verify system power environmentals are functional within spec
       # Expected state of power
       expected_output: ok
@@ -38,6 +41,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_system_environment_cooling_is_in_spec_on_
+      test_id: TN6.4
       description: Verify system cooling environmentals are functional within spec
       # Expected state of cooling
       expected_output: coolingOk
@@ -50,6 +54,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_fan_status_is_in_spec_on_
+      test_id: TN6.5
       description: Verify fan modules are functioning correctly
       # Expected state of cooling
       expected_output: ok

--- a/sample_network_tests/extension/test_definition.yaml
+++ b/sample_network_tests/extension/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_extension.py
   testcases:
     - name: test_if_extensions_are_installed_on_
+      test_id: TN7.1
       description: Verify a list of extension are installed on a DUT
       # List extensions to check on DUT
       extensions:
@@ -17,6 +18,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_extensions_are_erroring_on_
+      test_id: TN7.2
       description: Verify a list of extension are not erroring on a DUT
       # List extensions to check on DUT
       extensions:

--- a/sample_network_tests/filesystem/test_definition.yaml
+++ b/sample_network_tests/filesystem/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_filesystem.py
   testcases:
     - name: test_if_files_on_
+      test_id: TN8.1
       description: Verify filesystem is correct and expected files are present
       # List of files to check on DUT
       files:

--- a/sample_network_tests/host/test_definition.yaml
+++ b/sample_network_tests/host/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_host.py
   testcases:
     - name: test_if_hostname_is_correcet_on_
+      test_id: TN9.1
       description: Verify hostname is set correctly on device
       # DUT name is taken from the definitions file
       expected_output: null

--- a/sample_network_tests/interface/test_definition.yaml
+++ b/sample_network_tests/interface/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_interface.py
   testcases:
     - name: test_if_intf_protocol_status_is_connected_on_
+      test_id: TN10.1
       description: Verify the interfaces of interest protocol statuses are connected
       # interface protocol status
       expected_output: up
@@ -12,6 +13,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_link_status_is_connected_on_
+      test_id: TN10.2
       description: Verify the interfaces of interest link statuses are connected
       # interface link status
       expected_output: connected
@@ -23,6 +25,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_phy_status_connected_on_
+      test_id: TN10.3
       description: Verify the interfaces of interest physical state is link up
       # interface physical status
       expected_output: linkUp
@@ -34,6 +37,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_input_errors_on_
+      test_id: TN10.4
       description: Verify the interfaces of interest does not have input errors
       # Number of tolerable input errors
       expected_output: 0
@@ -45,6 +49,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_output_errors_on_
+      test_id: TN10.5
       description: Verify the interfaces of interest does not have output errors
       # Number of tolerable output errors
       expected_output: 0
@@ -56,6 +61,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_frame_too_short_errors_on_
+      test_id: TN10.6
       description: Verify the interfaces of interest have no frameTooShorts errors
       # Number of tolerable frameTooShorts errors
       expected_output: 0
@@ -67,6 +73,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_frame_too_long_errors_on_
+      test_id: TN10.7
       description: Verify the interfaces of interest have no frameTooLong errors
       # Number of tolerable frameLongShorts errors
       expected_output: 0
@@ -78,6 +85,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_fcs_errors_on_
+      test_id: TN10.8
       description: Verify the interfaces of interest have no fcsErrors errors
       # Number of tolerable fcsErrors errors
       expected_output: 0
@@ -89,6 +97,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_alignment_errors_on_
+      test_id: TN10.9
       description: Verify the interfaces of interest have no alignmentErrors errors
       # Number of tolerable alignmentErrors errors
       expected_output: 0
@@ -100,6 +109,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_counters_has_symbol_errors_on_
+      test_id: TN10.10
       description: Verify the interfaces of interest have no symbolErrors errors
       # Number of tolerable symbolErrors errors
       expected_output: 0
@@ -111,6 +121,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_interface_errors_on_
+      test_id: TN10.11
       description: Verifies interfaces L1 errors (Rx, Giants, Tx, Runts, FCS, Align)
       # Number of tolerable errors
       expected_output: 0
@@ -122,6 +133,7 @@
         - DSR01
         - DCBBW1
     - name: test_interface_utilization_on_
+      test_id: TN10.12
       description: Verify input and output bandwidth utilization of interfaces
       # Number of tolerable errors
       expected_output: 70
@@ -133,6 +145,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_out_counters_are_discarding_on_
+      test_id: TN10.13
       description: Verify the interfaces of interest have no outDiscards
       # Number of tolerable outDiscards errors
       expected_output: 0
@@ -144,6 +157,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_in_counters_are_discarding_on_
+      test_id: TN10.14
       description: Verify the interfaces of interest have no inDiscards
       # Number of tolerable inDiscards errors
       expected_output: 0
@@ -155,6 +169,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_intf_mtu_is_correct_on_
+      test_id: TN10.15
       description: Verify the interfaces of interest MTU
       # Interface MTU size
       expected_output: 1500

--- a/sample_network_tests/lldp/test_definition.yaml
+++ b/sample_network_tests/lldp/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_lldp.py
   testcases:
     - name: test_if_lldp_rx_is_enabled_on_
+      test_id: TN11.1
       description: Verify LLDP receive is enabled on interesting interfaces
       # LLDP RX state
       show_cmd: show lldp
@@ -14,6 +15,7 @@
         - DLFW4
 
     - name: test_if_lldp_tx_is_enabled_on_
+      test_id: TN11.2
       description: Verify LLDP transmit is enabled on interesting interfaces
       # LLDP TX state
       expected_output: true
@@ -27,6 +29,7 @@
         - DLFW4
 
     - name: test_if_lldp_system_name_is_correct_on_
+      test_id: TN11.3
       description: Verify show lldp local-info hostname is the system's name
       # Use dut name
       expected_output: null
@@ -40,6 +43,7 @@
         - DLFW4
 
     - name: test_if_lldp_max_frame_size_is_correct_on_
+      test_id: TN11.4
       description: Verify show lldp local-info maxFrameSize is correct
       # LLDP Max frame size
       expected_output: 9236
@@ -53,6 +57,7 @@
         - DLFW4
 
     - name: test_if_lldp_interface_id_is_correct_on_
+      test_id: TN11.5
       description: Verify show lldp local-info interfaceIdType is correct
       # LLDP ID type
       expected_output: interfaceName

--- a/sample_network_tests/log/test_definition.yaml
+++ b/sample_network_tests/log/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_logging.py
   testcases:
     - name: test_if_log_messages_appear_on_
+      test_id: TN12.1
       description: Verify local log messages
       show_cmd: show logging
       test_criteria: Verify local log messages

--- a/sample_network_tests/memory/test_definition.yaml
+++ b/sample_network_tests/memory/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_memory.py
   testcases:
     - name: test_memory_utilization_on_
+      test_id: TN13.1
       description: Verify memory is not exceeding high utilization
       show_cmd: show version
       # memory process ceiling

--- a/sample_network_tests/ntp/test_definition.yaml
+++ b/sample_network_tests/ntp/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_ntp.py
   testcases:
     - name: test_if_ntp_is_synchronized_on_
+      test_id: TN14.1
       description: Verify ntp is setup and working correctly
       show_cmd: show ntp status
       expected_output: synchronised
@@ -12,6 +13,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_ntp_associated_with_peers_on_
+      test_id: TN14.2
       description: Verify there are at least expected number of ntp peers
       show_cmd: show ntp associations
       # number of ntp associations
@@ -24,6 +26,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_process_is_running_on_
+      test_id: TN14.3
       description: Verify there are at least expected number of ntp processes running
       show_cmd: show processes
       # processes to check
@@ -38,6 +41,7 @@
         - DSR01
         - DCBBW1
     - name: test_ntp_configuration_on_
+      test_id: TN14.4
       description: Verifies NTP configuration matches the recommended practices 
       show_cmd: show running-config section ntp
       # List of NTP servers
@@ -54,6 +58,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_ntp_servers_are_reachable_on_
+      test_id: TN14.5
       description: Verifies NTP servers are reachable via ping
       show_cmd: null
       # List of NTP servers

--- a/sample_network_tests/system/test_definition.yaml
+++ b/sample_network_tests/system/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_system.py
   testcases:
     - name: test_if_there_is_agents_have_crashed_on_
+      test_id: TN15.1
       description: Verifies the agents logs crash is empty
       show_cmd: show agent logs crash
       expected_output: 0
@@ -12,6 +13,7 @@
         - DSR01
         - DCBBW1
     - name: test_if_eos_version_is_correct_on_
+      test_id: TN15.2
       description: Verifies EOS version running on the device 
       show_cmd: show version
       # EOS version name

--- a/sample_network_tests/tacacs/test_definition.yaml
+++ b/sample_network_tests/tacacs/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_tacacs.py
   testcases:
     - name: test_if_tacacs_is_sending_messages_on_
+      test_id: TN16.1
       description: Verify tacacs messages are sending correctly
       show_cmd: show tacacs
       expected_output: null
@@ -14,6 +15,7 @@
       comment: null
       result: True
     - name: test_if_tacacs_is_receiving_messages_on_
+      test_id: TN16.2
       description: Verify tacacs messages are received correctly
       show_cmd: show tacacs
       expected_output: null

--- a/sample_network_tests/users/test_definition.yaml
+++ b/sample_network_tests/users/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_users.py
   testcases:
     - name: test_if_usernames_are_configured_on_
+      test_id: TN17.1
       description: Verify username is set correctly
       # List usernames to check on DUT
       usernames:

--- a/sample_network_tests/ztp/test_definition.yaml
+++ b/sample_network_tests/ztp/test_definition.yaml
@@ -1,6 +1,7 @@
 - name: test_ztp.py
   testcases:
     - name: test_if_zerotouch_is_disabled_on_
+      test_id: TN18.1
       description: Verify zerotouch-config is disabled 
       show_cmd: show zerotouch
       expected_output: disabled
@@ -11,6 +12,7 @@
         - DSR01
         - DCBBW1
     - name: test_for_zerotouch_config_file_on_
+      test_id: TN18.2
       description: Verify zerotouch-config file is on flash
       show_cmd: dir flash:zerotouch-config
       expected_output: True


### PR DESCRIPTION
# Please include a summary of the changes

* test_definition.yaml of all sample network test cases

# Any specific logic/part of code you need extra attention on

Did not add test case id's to the tests in vane_system_tests, since those are not network tests, should we add id's for those as well? Also should the vane_system_tests be placed in sample network tests folder?

# Include the Issue number and link

#601 #136 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

The reports generated now have ID's. However the order of test cases is not maintained in the reports, is that expected, can see below: (10->18->12)

    
<img width="676" alt="Screenshot 2023-11-06 at 2 22 10 PM" src="https://github.com/aristanetworks/vane/assets/123415500/30a255af-2943-480d-ba90-269ac8509aa5">

# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
