### PR TITLE
Removed --environment flag

### DIFF
--- a/tests/unittests/test_vane_cli.py
+++ b/tests/unittests/test_vane_cli.py
@@ -221,7 +221,6 @@ def test_main_definitions_and_duts(loginfo, logwarning, mocker):
         return_value=argparse.Namespace(
             definitions_file="definitions_sample.yaml",
             duts_file="duts_sample.yaml",
-            environment="test",
             generate_duts_file=None,
             generate_duts_from_topo=None,
             generate_test_steps=None,
@@ -231,7 +230,6 @@ def test_main_definitions_and_duts(loginfo, logwarning, mocker):
     )
     vane_cli.main()
 
-    assert vane.config.ENVIRONMENT == "test"
     assert vane.config.DEFINITIONS_FILE == "definitions_sample.yaml"
     assert vane.config.DUTS_FILE == "duts_sample.yaml"
 
@@ -264,7 +262,6 @@ def test_main_create_duts_file(loginfo, logwarning, mocker):
         return_value=argparse.Namespace(
             definitions_file="definitions_sample.yaml",
             duts_file="duts_sample.yaml",
-            environment="test",
             generate_duts_file=["topology.yaml", "inventory.yaml"],
             generate_duts_from_topo=None,
             generate_test_steps=None,
@@ -309,7 +306,6 @@ def test_main_generate_duts_from_topo(loginfo, logwarning, mocker):
         return_value=argparse.Namespace(
             definitions_file="definitions_sample.yaml",
             duts_file="duts_sample.yaml",
-            environment="test",
             generate_duts_file=None,
             generate_duts_from_topo=["topology.yaml"],
             generate_test_steps=None,
@@ -349,7 +345,6 @@ def test_main_write_test_steps(loginfo, mocker):
         return_value=argparse.Namespace(
             definitions_file="definitions_sample.yaml",
             duts_file="duts_sample.yaml",
-            environment="test",
             generate_duts_file=None,
             generate_duts_from_topo=None,
             generate_test_steps="test_directory",

--- a/vane/config.py
+++ b/vane/config.py
@@ -3,7 +3,6 @@ To set the default values of global parameters.
 """
 DEFINITIONS_FILE = "definitions.yaml"
 DUTS_FILE = "duts.yaml"
-ENVIRONMENT = "test"
 test_defs = {}
 test_duts = {}
 test_parameters = {}

--- a/vane/vane_cli.py
+++ b/vane/vane_cli.py
@@ -74,12 +74,6 @@ def parse_cli():
     )
 
     parser.add_argument(
-        "--environment",
-        default=vane.config.ENVIRONMENT,
-        help="Specify the test execution environment",
-    )
-
-    parser.add_argument(
         "--generate-duts-file",
         help="Create a duts file from topology and inventory file",
         nargs=2,
@@ -301,9 +295,6 @@ def main():
                 vane.config.DUTS_FILE = tests_tools.create_duts_file(
                     args.generate_duts_file[0], args.generate_duts_file[1]
                 )
-
-            if args.environment:
-                vane.config.ENVIRONMENT = args.environment
 
             if args.generate_duts_from_topo:
                 logging.info(


### PR DESCRIPTION
# Please include a summary of the changes

* vane_cli.py and config.py: removed the --environment flag
* test_vane_cli.py: refactored the relevant test cases

# Include the Issue number and link

#611 

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other : Refactor

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

All the test cases pass
    
<img width="1358" alt="Screenshot 2023-11-30 at 12 40 41 PM" src="https://github.com/aristanetworks/vane/assets/123415500/454e1e50-faf7-48af-9a03-9e2d2a76d958">

# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  
# Verify Documentation Update

Updated documentation to not have --environment flag in CLI reference guide