### PR TITLE
Issue #613: Setting strict to True, which was splitting the cmds being run through pyeapi

### DIFF
--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1420,9 +1420,9 @@ class TestOps:
                     run_cmds = render_cmds(dut, cmds)
                 # if encoding is json run the commands, store the results
                 if encoding == "json":
-                    json_results = conn.enable(run_cmds)
+                    json_results = conn.enable(run_cmds, strict=True)
                 # also run the commands in text mode
-                txt_results = conn.enable(run_cmds, encoding="text")
+                txt_results = conn.enable(run_cmds, strict=True, encoding="text")
             else:
                 # run the config cmd
                 txt_results = conn.config(cmds)


### PR DESCRIPTION

# Please include a summary of the changes

* File 1 and corresponding changes
vane/tests_tools.py: 
![Screenshot 2023-12-11 at 11 28 27 AM](https://github.com/aristanetworks/vane/assets/32338164/5e903aee-a2ba-4acb-90d1-826dc395007f)
I dont think we want to rerun commands as text if json is not available. However if strict is not set to True then, pyeapi passes each command in separate call so as to determine if the cmd failed because of json formatting. Thus the second command losses the context set by first command. 

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on

# Include the Issue number and link
#613 


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [X] Other (please specify)
Using pyeapi APIs with proper context here.

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
