### PR TITLE
Issue 619: Add support of running cfg and show commands together for …

### DIFF
--- a/sample_network_tests/vane_system_tests/test_definition.yaml
+++ b/sample_network_tests/vane_system_tests/test_definition.yaml
@@ -7,6 +7,12 @@
       expected_output: temp-hostname
       report_style: modern
       test_criteria: Verify setup comments are filtered properly
+    - name: test_if_ssh_text_cmds_mixed_batch_run
+      description: Verify running mixed batch cmds using ssh 
+      show_cmd: null
+      expected_output: null
+      report_style: modern
+      test_criteria: Verify cmds can be run using ssh with json encoding
     - name: test_if_ssh_json_cmds_run
       description: Verify running cmds using ssh with json encoding
       show_cmd: null

--- a/sample_network_tests/vane_system_tests/test_vane.py
+++ b/sample_network_tests/vane_system_tests/test_vane.py
@@ -127,6 +127,58 @@ class VaneTests:
         tops.generate_report(tops.dut_name, tops.output_msg)
         assert tops.actual_output == tops.expected_output
 
+    def test_if_ssh_text_cmds_mixed_batch_run(self, dut, tests_definitions):
+        """TD: Verifies cmds run using ssh and output is same as eapi
+
+        Args:
+          dut (dict): Encapsulates dut details including name, connection
+        """
+
+        tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
+
+        try:
+            tops.show_cmds[tops.dut_name] = ["vrf instance MGMTMGMT", "bash timeout 20 sudo tcpdump -vvni ma1 port 514"]
+
+            cmds=[]
+            cmd = {}
+            cmd["cmds"] = ["vrf instance MGMTMGMT"]
+            cmd["cmd_type"] = "cfg"
+            cmd["encoding"] = "text"
+            cmd_args = {}
+            cmd_args["read_timeout"] = 40
+            cmd_args["exit_config_mode"] = False
+            cmd["cmd_args"] = cmd_args
+            cmds.append(cmd)
+            cmd = {}
+            cmd["cmds"] = ["bash timeout 20 sudo tcpdump -vvni ma1 port 514"]
+            cmd["cmd_type"] = "show"
+            cmd["encoding"] = "text"
+            cmd_args = {}
+            cmd_args["read_timeout"] = 40
+            cmd_args["exit_config_mode"] = True
+            cmd["cmd_args"] = cmd_args
+            cmds.append(cmd)
+            """
+            TS: Run cmds using batch api with one cfg and one show cmd
+            """
+            tops.actual_output = tops.run_ssh_mixed_batch(cmds)
+
+        except (AttributeError, LookupError, EapiError) as exception:
+            logging.error(
+                f"On device {tops.dut_name}: Error while running testcase on DUT is: "
+                f"{str(exception)}"
+            )
+            tops.actual_output = str(exception)
+            tops.output_msg += (
+                f"EXCEPTION encountered on device {tops.dut_name}, while "
+                f"investigating if ssh can be used to run cmds. Vane recorded error: {exception}"
+            )
+
+        tops.parse_test_steps(self.test_if_ssh_text_cmds_mixed_batch_run)
+        tops.test_result = "error" not in tops.actual_output
+        tops.generate_report(tops.dut_name, tops.output_msg)
+        assert "error" not in tops.actual_output
+
     def test_if_ssh_text_cmds_run(self, dut, tests_definitions):
         """TD: Verifies cmds run using ssh and output is same as eapi
 

--- a/vane/device_interface.py
+++ b/vane/device_interface.py
@@ -221,7 +221,7 @@ class NetmikoConn(DeviceConn):
 
         return cmds, local_cmds
 
-    def send_list_cmds(self, cmds, encoding="json"):
+    def send_list_cmds(self, cmds, read_timeout, encoding="json"):
         """send_list_cmds: sends the list of commands to device conn
         and collects the output as list"""
 
@@ -229,11 +229,11 @@ class NetmikoConn(DeviceConn):
 
         for i, cmd in enumerate(cmds):
             try:
-                output = self._connection.send_command(cmd)
+                output = self._connection.send_command(cmd, read_timeout=read_timeout)
             except netmiko.exceptions.NetmikoTimeoutException:
                 # try resetting connection and see if it works
                 self.set_up_conn(self.name)
-                output = self._connection.send_command(cmd)
+                output = self._connection.send_command(cmd, read_timeout=read_timeout)
 
             if output not in error_responses:
                 if encoding == "json":
@@ -250,16 +250,16 @@ class NetmikoConn(DeviceConn):
 
         return cmds_op
 
-    def send_str_cmds(self, cmds, encoding="json"):
+    def send_str_cmds(self, cmds, read_timeout, encoding="json"):
         """send_str_cmds: sends one command to device conn"""
 
         cmds_op = []
         try:
-            output = self._connection.send_command(cmds)
+            output = self._connection.send_command(cmds, read_timeout=read_timeout)
         except netmiko.exceptions.NetmikoTimeoutException:
             # try resetting connection and see if it works
             self.set_up_conn(self.name)
-            output = self._connection.send_command(cmds)
+            output = self._connection.send_command(cmds, read_timeout=read_timeout)
 
         if output not in error_responses:
             if encoding == "json":
@@ -294,10 +294,15 @@ class NetmikoConn(DeviceConn):
             # when cmds is a string and encoding is text
             local_cmds = cmds
 
+        read_timeout = None
+        for key, value in kwargs.items():
+            if key == 'read_timeout':
+                read_timeout = value
+
         if isinstance(cmds, list):
-            cmds_op = self.send_list_cmds(cmds=local_cmds, encoding=encoding)
+            cmds_op = self.send_list_cmds(cmds=local_cmds, encoding=encoding, read_timeout=read_timeout)
         elif isinstance(cmds, str):
-            cmds_op = self.send_str_cmds(cmds=local_cmds, encoding=encoding)
+            cmds_op = self.send_str_cmds(cmds=local_cmds, encoding=encoding, read_timeout=read_timeout)
 
         return cmds_op
 
@@ -368,7 +373,14 @@ class NetmikoConn(DeviceConn):
         commands = list(commands)
 
         self._connection.enable()
-        response = self._connection.send_config_set(commands)
+        read_timeout = None
+        exit_config_mode = True
+        for key, value in kwargs.items():
+            if key == 'read_timeout':
+                read_timeout = value
+            elif key == 'exit_config_mode':
+                exit_config_mode = value
+        response = self._connection.send_config_set(commands, read_timeout=read_timeout, exit_config_mode=exit_config_mode)
 
         return response
 


### PR DESCRIPTION
…ssh conn

# Please include a summary of the changes

* modified:   sample_network_tests/vane_system_tests/test_definition.yaml
Added context for newly added test
* modified:   sample_network_tests/vane_system_tests/test_vane.py
Added test to test out new API added to tests_tools.py
* modified:   vane/device_interface.py
Added support for kwargs for ssh conn. Basically to pass read_timeout and exit_config_mode to netmiko APIs
* modified:   vane/tests_tools.py
Added `run_ssh_mixed_batch` API to pass cfg and show commands to ssh connection. Also modified _run_and_record_cmds to add support for kwargs. Right now it only passes kwargs to netmiko conn.

# Any specific logic/part of code you need extra attention on


# Include the Issue number and link
#619 


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [x] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?
Using sample_network_tests. I will add unit tests in a separate PR.
## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
