### PR TITLE
Update Vane-CVP build for 2023.2+ versions

### DIFF
--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -112,14 +112,18 @@ jobs:
           #
           version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
           #
+          # Get a timestamp for the build
+          #
+          timestamp=$(date -Iminutes)
+          #
           # If not on a published branch, append a provisional tag to the distribution name
           #
-          if [[ "main" =~ "${{github.ref}}" || "develop" =~ "${{github.ref}}" ]]; then
-            tag=""
-          elif [[ "gar-cvp-update" =~ "${{github.ref}}" ]]; then
-            tag="-test-build"
+          if [[ "${{github.ref}}" =~ "main" || "${{github.ref}}" =~ "develop" ]]; then
+            tag="${timestamp}"
+          elif [[ "${{github.ref}}" =~ "gar-cvp-update" ]]; then
+            tag="${timestamp}-test-build"
           else
-            tag="-provisional"
+            tag="${timestamp}-provisional"
           fi
           #
           # Create the distribution directory

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -114,7 +114,7 @@ jobs:
           #
           # Get a timestamp for the build
           #
-          timestamp=$(date -Iminutes)
+          timestamp=$(date +%Y-%m-%d_%H%M)
           #
           # If not on a published branch, append a provisional tag to the distribution name
           #

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -114,8 +114,10 @@ jobs:
           #
           # If not on a published branch, append a provisional tag to the distribution name
           #
-          if ${PUB_BRANCH} == true; then
+          if [[ "${{github.ref}}" == "main" -o "${{github.ref}}" == "develop" ]]; then
             tag=""
+          elif [[ "${{github.ref}}" == "gar-cvp-update" ]]; then
+            tag="-test-build"
           else
             tag="-provisional"
           fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -119,11 +119,11 @@ jobs:
           # If not on a published branch, append a provisional tag to the distribution name
           #
           if [[ "${{github.ref}}" =~ "main" || "${{github.ref}}" =~ "develop" ]]; then
-            tag="${timestamp}"
+            tag="-${timestamp}"
           elif [[ "${{github.ref}}" =~ "gar-cvp-update" ]]; then
-            tag="${timestamp}-test-build"
+            tag="-${timestamp}-test-build"
           else
-            tag="${timestamp}-provisional"
+            tag="-${timestamp}-provisional"
           fi
           #
           # Create the distribution directory

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -103,25 +103,21 @@ jobs:
           make rpm-cvp
 
       - name: Create a vane-cvp distribution directory based on the version being built
-        env:
-          # Check if we are on a published branch (main or develop)
-          PUB_BRANCH: ${{ contains(fromJSON('["main", "develop"]'), github.ref) }}
         run: |
           #
           # Get the version string from the pyproject.toml file
           #
           version_str=$(grep ^version pyproject.toml | awk -F " " '{print $NF}' | tr -d '"')
           #
-          # Get a timestamp for the build
+          # Get a timestamp for the build (no colon in the time - looks like a port number and
+          # causes problems later)
           #
           timestamp=$(date +%Y-%m-%d_%H%M)
           #
-          # If not on a published branch, append a provisional tag to the distribution name
+          # If not on the main or develop branch, append a provisional tag to the distribution name
           #
           if [[ "${{github.ref}}" =~ "main" || "${{github.ref}}" =~ "develop" ]]; then
             tag="-${timestamp}"
-          elif [[ "${{github.ref}}" =~ "gar-cvp-update" ]]; then
-            tag="-${timestamp}-test-build"
           else
             tag="-${timestamp}-provisional"
           fi

--- a/.github/workflows/cvp-extension-builder.yml
+++ b/.github/workflows/cvp-extension-builder.yml
@@ -114,9 +114,9 @@ jobs:
           #
           # If not on a published branch, append a provisional tag to the distribution name
           #
-          if [[ "${{github.ref}}" == "main" -o "${{github.ref}}" == "develop" ]]; then
+          if [[ "main" =~ "${{github.ref}}" || "develop" =~ "${{github.ref}}" ]]; then
             tag=""
-          elif [[ "${{github.ref}}" == "gar-cvp-update" ]]; then
+          elif [[ "gar-cvp-update" =~ "${{github.ref}}" ]]; then
             tag="-test-build"
           else
             tag="-provisional"

--- a/conf/cvpi/conf/components/vane-cvp.multinode.yaml
+++ b/conf/cvpi/conf/components/vane-cvp.multinode.yaml
@@ -3,8 +3,6 @@ vane-cvp-image:
     load:
       command: [ "${CVP_HOME}/bin/image-load.sh", "vane-cvp" ]
       nodes: { "*" }
-      deps:
-        docker: start
       timeout: 300s
 
 vane-cvp:

--- a/conf/cvpi/conf/components/vane-cvp.singlenode.yaml
+++ b/conf/cvpi/conf/components/vane-cvp.singlenode.yaml
@@ -3,8 +3,6 @@ vane-cvp-image:
     load:
       command: [ "${CVP_HOME}/bin/image-load.sh", "vane-cvp" ]
       nodes: { "*" }
-      deps:
-        docker: start
       timeout: 300s
 
 vane-cvp:

--- a/resources/vane-cvp-install.sh
+++ b/resources/vane-cvp-install.sh
@@ -42,6 +42,7 @@ trap exit_trap EXIT
 echo -e $divider
 echo -e "Install the rpm\n"
 rm -f /home/cvp/vane-cvp*.rpm
+rm -f /data/apprpms/vane-cvp*.rpm
 cp ${script_path}/vane-cvp*.rpm /home/cvp/
 cvpi install -f /home/cvp/vane-cvp*.rpm
 rm -f /home/cvp/vane-cvp*.rpm

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -38,7 +38,15 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # Handle errors then exit
 trap exit_trap EXIT
 
-# Remove the container images first
+# Stop the extension first
+#  - Later iterations seem to require the extension to be stopped before the
+#    containers can be removed (containers must not be in use)
+echo -e $divider
+echo -e "Stop the extension\n"
+mycommand="cvpi stop -f vane-cvp"
+result=$($mycommand 2>&1)
+
+# Remove the container images
 #  - If the uninstallation fails for some reason, at least the containers are removed
 #  - If the containers do not exist, the commands do not fail and the uninstallation will
 #    still proceed afterwards
@@ -49,12 +57,6 @@ nerdctl rmi -f vane-cvp
 if [ ! -z ${img_id:+x} ]; then
   nerdctl rmi -f ${img_id}
 fi
-
-# Stop the extension
-echo -e $divider
-echo -e "Stop the extension\n"
-mycommand="cvpi stop -f vane-cvp"
-result=$($mycommand 2>&1)
 
 # Disable the extension
 echo -e $divider


### PR DESCRIPTION
# Please include a summary of the changes

CVP 2023.2+ removed docker and replaced with containerd, which caused some issues with the Vane CVP extension. These changes address those issues, plus a few minor enhancements to the build process.

* conf/cvpi/conf/components/vane-cvp.multinode.yaml - remove dependency on docker (this still works on older versions of CVP where docker is used)
* conf/cvpi/conf/components/vane-cvp.singlenode.yaml - remove dependency on docker as above
* .github/workflows/cvp-extension-builder.yml - rework the tagging section to add a 'provisional' tag when building a branch other than main or develop. Also adds a timestamp to the directory structure, so the download is clear when it was built. The RPM file name stays unchanged (no timestamp or provisional tag either way).
* resources/vane-cvp-install.sh - ensure old versions of RPM are removed from /data/apprmps before installation to prevent confusing re-installs of old version when trying to update
* resources/vane-cvp-uninstall.sh - stop the extension before deleting containers, seems to be a requirement with containerd (still works with docker on older versions)

# Any specific logic/part of code you need extra attention on

See file changes explained above

# Include the Issue number and link

Hot fix - no issue

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

Manually tested changes with ACT and with David Gonzalez CVP instance.
    
   
# CI pipeline result

- - [ ] Pass
- - [X] Fail
  
Failing on pip install due to incorrect parameters being checked in the pipeline. Pipeline needs updated
Failing on coverage due
  
# Verify Documentation Update

N/A
    
# Additional comments
