### PR TITLE
skip test_routing_evpn_l2vni_imet if evpn not configured

### DIFF
--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -70,7 +70,8 @@ class EvpnRoutingTests:
                     evpn_running = True
                     break
 
-            assert evpn_running, "EVPN is not configured on the device."
+            if evpn_running:
+                pytest.skip(f"EVPN is not configured on {tops.dut_name}.")
 
             bgp_evpn_peer = ""
             for vrf in vrf_details:

--- a/nrfu_tests/test_routing_evpn_l2vni_imet.py
+++ b/nrfu_tests/test_routing_evpn_l2vni_imet.py
@@ -70,7 +70,7 @@ class EvpnRoutingTests:
                     evpn_running = True
                     break
 
-            if evpn_running:
+            if not evpn_running:
                 pytest.skip(f"EVPN is not configured on {tops.dut_name}.")
 
             bgp_evpn_peer = ""


### PR DESCRIPTION
# Please include a summary of the changes

* nrfu_tests/test_routing_evpn_l2vni_imet.py

# Any specific logic/part of code you need extra attention on

Changed logic to skip switches that do not have EVPN tenants.  Previously, test cases failed these switches.

# Include the Issue number and link

NRFU 4.3 - test case test_routing_evpn_l2vni_imet is broken #663

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [x] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

Yes: https://github.com/aristanetworks/ps-demos/actions/runs/8236888452

## Bug fix

See above
        
# CI pipeline result

- - [x] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

N/A
    
# Additional comments
