### PR TITLE
Issue_660: Fixed NRFU1.2 NtpAssocitionsTests - Tests incorrectly failing

### DIFF
--- a/nrfu_tests/master_def.yaml
+++ b/nrfu_tests/master_def.yaml
@@ -7,6 +7,8 @@ testcase_data:
     dns_name_server_check: # If you want the test case to fail when a name-server is not configured on the device, change these parameters to True for the IP version you need.
       ipv4_fail_if_not_configured: True
       ipv6_fail_if_not_configured: False
+  NRFU1.2:
+    single_ntp_check: False # Single NTP server verification, set the value as True when single ntp server verification needed.
   NRFU2.1:
     descriptions_to_ignore: # Interfaces to ignore the following descriptions
       - unused

--- a/nrfu_tests/test_base_services_ntp_association.py
+++ b/nrfu_tests/test_base_services_ntp_association.py
@@ -14,7 +14,7 @@ logging = test_case_logger.setup_logger(__file__)
 
 @pytest.mark.nrfu_test
 @pytest.mark.base_services
-class NtpAssocitionsTests:
+class NtpAssociationsTests:
     """Testcases for verification of NTP association functionality"""
 
     dut_parameters = tests_tools.parametrize_duts(TEST_SUITE, test_defs, dut_objs)
@@ -31,15 +31,28 @@ class NtpAssocitionsTests:
         """
         tops = tests_tools.TestOps(tests_definitions, TEST_SUITE, dut)
         self.output = ""
+        test_params = tops.test_parameters
         tops.actual_output = {
             "primary_ntp_association": "Not found",
             "secondary_ntp_association": "Not found",
         }
-        # Forming an output message if a test result is pass
+        single_ntp_check = test_params["input"].get("single_ntp_check")
         tops.output_msg = (
-            "NTP server is configured on the device. Primary and secondary NTP association is"
-            " correct on the device."
+            "NTP server should be configured on the device. Primary and secondary NTP association"
+            " is correct on the device."
         )
+        if single_ntp_check:
+            tops.expected_output = {"primary_ntp_association": "sys.peer"}
+            # Forming an output message if a test result is pass
+            tops.output_msg = (
+                "NTP server should be configured on the device. Primary NTP association is correct"
+                " on the device."
+            )
+            tops.test_criteria = (
+                "NTP server should be configured on the device. Primary NTP association should be "
+                "correct on the device. "
+            )
+            tops.actual_output = {"primary_ntp_association": "Not found"}
 
         try:
             """
@@ -53,13 +66,18 @@ class NtpAssocitionsTests:
 
             # Skipping testcase if NTP server is not configured on DUT.
             if output.get("status") == "disabled":
-                pytest.skip(f"NTP server is not configured on device {tops.dut_name}.")
+                tops.output_msg = (
+                    f"Skipping test case on device {tops.dut_name} as"
+                    " NTP server is not configured on device."
+                )
+                tests_tools.post_process_skip(tops, self.test_ntp_clocks, self.output)
+                pytest.skip(tops.output_msg)
 
             ntp_association_cmd = "show ntp associations"
 
             """
             TS: Running `show ntp associations` on device and verifying that the
-            primary and secondary NTP association is correct on the host.
+            expected NTP association is correct on the host.
             """
             output = tops.run_show_cmds([ntp_association_cmd])
             logging.info(
@@ -67,35 +85,37 @@ class NtpAssocitionsTests:
             )
             self.output += f"Output of {ntp_association_cmd} command is: \n{output}"
             ntp_associations = output[0]["result"].get("peers")
-            assert ntp_associations, "NTP association details are not collected."
+            assert (
+                ntp_associations
+            ), "NTP association details are not collected in the command output."
 
-            for peer in ntp_associations:
-                if ntp_associations[peer].get("condition") == "sys.peer":
+            for _, peer_details in ntp_associations.items():
+                if peer_details.get("condition") == "sys.peer":
                     tops.actual_output["primary_ntp_association"] = "sys.peer"
-                elif ntp_associations[peer].get("condition") == "candidate":
-                    tops.actual_output["secondary_ntp_association"] = "candidate"
+                if not single_ntp_check:
+                    if peer_details.get("condition") == "candidate":
+                        tops.actual_output["secondary_ntp_association"] = "candidate"
 
             # Forming an output message if a test result is fail
             if tops.actual_output != tops.expected_output:
                 tops.output_msg = ""
-                not_primary_ntp_association = (
-                    tops.actual_output["primary_ntp_association"]
-                    != tops.expected_output["primary_ntp_association"]
-                )
-                not_secondary_ntp_association = (
-                    tops.actual_output["secondary_ntp_association"]
-                    != tops.expected_output["secondary_ntp_association"]
-                )
-                if not_primary_ntp_association and not_secondary_ntp_association:
-                    tops.output_msg += (
-                        "Primary and Secondary NTP associations are not found on the device.\n"
-                    )
-                elif not_primary_ntp_association:
+                not_primary_ntp_association = tops.actual_output.get(
+                    "primary_ntp_association"
+                ) != tops.expected_output.get("primary_ntp_association")
+                not_secondary_ntp_association = tops.actual_output.get(
+                    "secondary_ntp_association"
+                ) != tops.expected_output.get("secondary_ntp_association")
+                if not_primary_ntp_association:
                     tops.output_msg += "Primary NTP association is not found on the device.\n"
-                elif not_secondary_ntp_association:
-                    tops.output_msg += "Secondary NTP association is not found on the device."
+                elif not single_ntp_check:
+                    if not_secondary_ntp_association:
+                        tops.output_msg += "Secondary NTP association is not found on the device."
 
-        except (AssertionError, AttributeError, LookupError, EapiError) as excp:
+        # For BaseException test case is failing instead of skipping it. Hence adding
+        # specific exception here.
+        except pytest.skip.Exception:
+            pytest.skip(tops.output_msg)
+        except (BaseException, EapiError) as excp:
             tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
             logging.error(
                 f"On device {tops.dut_name}: Error occurred while running testcase"

--- a/nrfu_tests/test_base_services_ntp_association.py
+++ b/nrfu_tests/test_base_services_ntp_association.py
@@ -48,7 +48,7 @@ class NtpAssociationsTests:
                 "NTP server should be configured on the device. Primary NTP association is correct"
                 " on the device."
             )
-            tops.test_criteria = (
+            test_params["test_criteria"] = (
                 "NTP server should be configured on the device. Primary NTP association should be "
                 "correct on the device. "
             )
@@ -64,7 +64,6 @@ class NtpAssociationsTests:
                 f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
             )
             self.output = f"Output of {tops.show_cmd} command is: \n{output}\n"
-
             # Skipping testcase if NTP server is not configured on DUT.
             if output.get("status") == "disabled":
                 tops.output_msg = (

--- a/nrfu_tests/test_base_services_ntp_association.py
+++ b/nrfu_tests/test_base_services_ntp_association.py
@@ -64,6 +64,7 @@ class NtpAssociationsTests:
                 f"On device {tops.dut_name}, output of {tops.show_cmd} command is:\n{output}\n"
             )
             self.output = f"Output of {tops.show_cmd} command is: \n{output}\n"
+
             # Skipping testcase if NTP server is not configured on DUT.
             if output.get("status") == "disabled":
                 tops.output_msg = (
@@ -76,7 +77,7 @@ class NtpAssociationsTests:
             ntp_association_cmd = "show ntp associations"
 
             """
-            TS: Running `show ntp associations` command on the device and verifying that the 
+            TS: Running `show ntp associations` command on the device and verifying that the
             NTP association is correct on the host.
             """
             output = tops.run_show_cmds([ntp_association_cmd])
@@ -113,11 +114,7 @@ class NtpAssociationsTests:
                 elif not single_ntp_check and no_secondary_ntp:
                     tops.output_msg += "Secondary NTP association is not found on the device."
 
-        # For BaseException test case is failing instead of skipping it. Hence adding
-        # specific exception here.
-        except pytest.skip.Exception:
-            pytest.skip(tops.output_msg)
-        except (BaseException, EapiError) as excp:
+        except (AssertionError, AttributeError, LookupError, EapiError) as excp:
             tops.actual_output = tops.output_msg = str(excp).split("\n", maxsplit=1)[0]
             logging.error(
                 f"On device {tops.dut_name}: Error occurred while running testcase"

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -22,6 +22,8 @@
         secondary_ntp_association: candidate
       test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device. # Setting test case’s pass/fail criteria for reporting
       report_style: modern # Setting report_style as modern, If a report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
+      input:
+        single_ntp_check: False # Single NTP server verification, set the value as True when single ntp server verification needed.
       criteria: names
       filter:
         - BLFE1

--- a/nrfu_tests/test_definition.yaml
+++ b/nrfu_tests/test_definition.yaml
@@ -20,7 +20,7 @@
       expected_output:
         primary_ntp_association: sys.peer
         secondary_ntp_association: candidate
-      test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device. # Setting test case’s pass/fail criteria for reporting
+      test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device. # Setting test case’s pass/fail criteria for reporting when the both NTP servers associations are correct on the device
       report_style: modern # Setting report_style as modern, If a report type is set to modern, then it will update steps, assumptions, and external systems in the docx report.
       input:
         single_ntp_check: False # Single NTP server verification, set the value as True when single ntp server verification needed.

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -16,12 +16,15 @@
     - name: test_ntp_clocks
       description: Test case to verify that 2 NTP clocks(a peer and a candidate) are locked on the device.
       test_id: NRFU1.2
+      {% set test_data = testcase_data["NRFU1.2"] %}
       show_cmd: show ntp status
       expected_output:
         primary_ntp_association: sys.peer
         secondary_ntp_association: candidate
       test_criteria: NTP server should be configured on the device. Primary and secondary NTP association should be correct on the device.
       report_style: modern
+      input:
+        single_ntp_check: {{ test_data.single_ntp_check }}
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_redundant_sso_card


### PR DESCRIPTION
# Please include a summary of the changes
- Updated nrfu_tests/master_def.yaml with NRFU1.2 testcase changes
- Updated nrfu_tests/test_base_services_ntp_association.py  with the support for single ntp server
- Updated nrfu_tests/test_definition.yaml with NRFU1.2 testcase changes
-Updated nrfu_tests/test_definition.yaml.j2 with NRFU1.2 testcase changes

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on

# Include the Issue number and link
#660 
Make sure to link the issue in the github PR UI 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [x] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
Reports:
- Tested with single NTP server check is True and the secondary server is not found: Passed (Tested with hardcoded output)
[report_pass_ntp_single_check_True_sec_association_not_found.docx](https://github.com/aristanetworks/vane/files/14663935/report_pass_ntp_single_check_True_sec_association_not_found.docx)



- Tested with single NTP server check is True: Passed
  [report_pass_ntp_single_check_True.docx](https://github.com/aristanetworks/vane/files/14663937/report_pass_ntp_single_check_True.docx)


- Tested with a single NTP server check is False: Passed
  [report_pass_ntp_single_check_false.docx](https://github.com/aristanetworks/vane/files/14663939/report_pass_ntp_single_check_false.docx)



-  Tested with a single NTP server check is False, and secondary ntp server association is not present: Failed  (Tested with hardcoded output)
    [report_fail_ntp_single_check_false_sec_association_not_found.docx](https://github.com/aristanetworks/vane/files/14663943/report_fail_ntp_single_check_false_sec_association_not_found.docx)


- Tested with NTP server is not configured: Skipped
  [report_ntp_skipped.docx](https://github.com/aristanetworks/vane/files/14663947/report_ntp_skipped.docx)


- Tested with NTP server association details  not found: Failed
  [report_ntp_servr_association_not_found.docx](https://github.com/aristanetworks/vane/files/14663960/report_ntp_servr_association_not_found.docx)


**HTML Reports**
[NRFU_1_2.zip](https://github.com/aristanetworks/vane/files/14663963/NRFU_1_2.zip)











