### PR TITLE
nrfu6.3 ignores minidump directory

### DIFF
--- a/nrfu_tests/test_system_hardware_coredump.py
+++ b/nrfu_tests/test_system_hardware_coredump.py
@@ -50,6 +50,8 @@ class CoreDumpFilesTests:
             )
             self.output = f"Output of {tops.show_cmd} command is:\n{core_dump}"
             core_dump = core_dump["coreFiles"]
+            if "minidump" in core_dump:
+                core_dump.remove("minidump")
             tops.actual_output["core_dump_files_not_found"] = not bool(core_dump)
 
             # Output message formation in case test case fails.


### PR DESCRIPTION
# Please include a summary of the changes

* nrfu_tests/test_system_hardware_coredump.py

# Any specific logic/part of code you need extra attention on
Ignore minidump directory.  Seems to be a software artifact in EOS that isn't used.

# Include the Issue number and link

https://github.com/aristanetworks/vane/issues/667

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [x] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

https://github.com/aristanetworks/ps-demos/actions/runs/8238515372
    
# CI pipeline result

- - [x] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  

