### PR TITLE
Adding logic for graceful failure handling when no duts are available

### DIFF
--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -203,6 +203,15 @@ def init_duts(show_cmds, test_parameters, test_duts):
     duts = login_duts(test_parameters, test_duts)
     workers = len(duts)
 
+    if not workers:
+        print(
+            "\x1b[31mNo valid DUTs to run tests on, hence exiting Vane.\n"
+            "If you are running on/via a CVP instance ensure your DUTs are"
+            " not in the undefined container.\n"
+            "Look at the logs for further details. \x1b[0m"
+        )
+        sys.exit(1)
+
     logging.debug(f"Duts login info: {duts} and create {workers} workers")
     logging.debug(f"Passing the following show commands to workers: {show_cmds}")
 


### PR DESCRIPTION
… to run tests on

# Please include a summary of the changes

* tests_tools.py: added logic for exiting Vane when no duts are available. This error is more likely to happen when running Vane on CVP instance in case the duts are in undefined container since we filter out duts which are in undefined container.

# Include the Issue number and link

#684 


# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

All current tests pass and in case 0 duts are found the error gets thrown correctly and Vane exits out

# CI pipeline result

- - [X] Pass
- - [ ] Fail
 