### PR TITLE
Update Vane-CVP uninstall script for docker vs nerdctl command

### DIFF
--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -33,11 +33,11 @@ function exit_trap {
   fi
 }
 
-# Determine if we are using docker or containerd
-if ! command -v nerdctl &> /dev/null; then
-  CONT_CMD=docker
-else
-  CONT_CMD=nerdctl
+# Set the CONTAINER_CMD to either docker or nerdctl. Use docker if nerdctl is not available.
+# Docker is used on older releases of CVP, nerdctl is used on newer releases.
+CONTAINER_CMD=nerdctl
+if ! command -v ${CONTAINER_CMD} &> /dev/null; then
+  CONTAINER_CMD=docker
 fi
 
 # Keep track of the last executed command
@@ -59,10 +59,10 @@ result=$($mycommand 2>&1)
 #    still proceed afterwards
 echo -e $divider
 echo -e "Remove the container images\n"
-img_id=`${CONT_CMD} images | grep vane-cvp | awk '{print $3}'`
-${CONT_CMD} rmi -f vane-cvp
+img_id=`${CONTAINER_CMD} images | grep vane-cvp | awk '{print $3}'`
+${CONTAINER_CMD} rmi -f vane-cvp
 if [ ! -z ${img_id:+x} ]; then
-  ${CONT_CMD} rmi -f ${img_id}
+  ${CONTAINER_CMD} rmi -f ${img_id}
 fi
 
 # Disable the extension

--- a/resources/vane-cvp-uninstall.sh
+++ b/resources/vane-cvp-uninstall.sh
@@ -33,6 +33,13 @@ function exit_trap {
   fi
 }
 
+# Determine if we are using docker or containerd
+if ! command -v nerdctl &> /dev/null; then
+  CONT_CMD=docker
+else
+  CONT_CMD=nerdctl
+fi
+
 # Keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # Handle errors then exit
@@ -52,10 +59,10 @@ result=$($mycommand 2>&1)
 #    still proceed afterwards
 echo -e $divider
 echo -e "Remove the container images\n"
-img_id=`nerdctl images | grep vane-cvp | awk '{print $3}'`
-nerdctl rmi -f vane-cvp
+img_id=`${CONT_CMD} images | grep vane-cvp | awk '{print $3}'`
+${CONT_CMD} rmi -f vane-cvp
 if [ ! -z ${img_id:+x} ]; then
-  nerdctl rmi -f ${img_id}
+  ${CONT_CMD} rmi -f ${img_id}
 fi
 
 # Disable the extension


### PR DESCRIPTION
# Please include a summary of the changes

Older versions of CVP use docker, newer versions use containerd which uses the nerdctl command to handle containers.
During uninstallation, we remove the containers related to the Vane-CVP extension. We need to check whether we are working with docker or nerdctl before doing the container removal. In the steps, we assume we are using nerdctl, then check for the nerdctl command. If it doesn't exist, we switch to the docker command.

# Any specific logic/part of code you need extra attention on

Operation should behave as explained above

# Include the Issue number and link

Hotfix - no related issue

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

Manual testing on versions of CVP that use both container tools (docker and nerdctl).
- Install the Vane extension and make sure it runs
- Uninstall the Vane extension and make sure there were no errors and the containers were reported as removed

    
   
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  
  
# Verify Documentation Update

N/A
    
# Additional comments

N/A