### PR TITLE
678 nrfu611 test system temperature sensors

### DIFF
--- a/nrfu_tests/test_hardware_power_supply_voltage_status.py
+++ b/nrfu_tests/test_hardware_power_supply_voltage_status.py
@@ -56,6 +56,7 @@ class PowerSupplyVoltageTests:
             self.output += f"\nOutput of {tops.show_cmd} command is:\n{version_output}\n"
 
             # Skipping test case if the device is vEOS.
+            model = version_output.get("modelName")
             if "vEOS" in version_output.get("modelName"):
                 pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
 

--- a/nrfu_tests/test_hardware_power_supply_voltage_status.py
+++ b/nrfu_tests/test_hardware_power_supply_voltage_status.py
@@ -58,7 +58,7 @@ class PowerSupplyVoltageTests:
             # Skipping test case if the device is vEOS.
             model = version_output.get("modelName")
             if "vEOS" in version_output.get("modelName"):
-                pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
+                pytest.skip(f"{tops.dut_name} is {model} device, hence test skipped.")
 
             """
             TS: Running `show system environment power voltage` command on the device and

--- a/nrfu_tests/test_system_hardware_fan_status.py
+++ b/nrfu_tests/test_system_hardware_fan_status.py
@@ -59,7 +59,8 @@ class SystemHardwareFanStatusTests:
             )
 
             # Skipping test case if the device is vEOS.
-            if "vEOS" in output.get("modelName"):
+            model = output.get("modelName")
+            if "vEOS" in model:
                 pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
 
             """
@@ -76,7 +77,10 @@ class SystemHardwareFanStatusTests:
             # Checking power supply slot and Fan tray slot details.
             self.power_supply_slots = self.fan_slot_details.get("powerSupplySlots")
             self.fan_tray_slots = self.fan_slot_details.get("fanTraySlots")
-            assert self.power_supply_slots, "Power supply slot details are not found in the output."
+            if "7010" not in model:
+                assert (
+                    self.power_supply_slots
+                ), "Power supply slot details are not found in the output."
 
             assert self.fan_tray_slots, "Fan tray slot details are not found in the output."
 

--- a/nrfu_tests/test_system_hardware_temperature.py
+++ b/nrfu_tests/test_system_hardware_temperature.py
@@ -168,8 +168,9 @@ class SystemHardwareTemperatureTests:
             self.output += f"\nOutput of 'show version' command is: \n{self.version_output}"
 
             # Skipping test case if the device is vEOS.
-            if "vEOS" in self.version_output.get("modelName"):
-                pytest.skip(f"{tops.dut_name} is vEOS device, hence test skipped.")
+            model = self.version_output.get("modelName")
+            if "vEOS" in model or "7010" in model:
+                pytest.skip(f"{tops.dut_name} is {model} device, hence test skipped.")
 
             """
             TS: Running the "show system environment temperature" command on DUT and


### PR DESCRIPTION
# Please include a summary of the changes

* nrfu_tests/test_hardware_power_supply_voltage_status.py
* nrfu_tests/test_system_hardware_fan_status.py
* nrfu_tests/test_system_hardware_temperature.py

# Any specific logic/part of code you need extra attention on

Arista 7010 switch does not have power supply sensors.  Corrections are made to skip the switch if needed or reduce the testing requirements.

# Include the Issue number and link
https://github.com/aristanetworks/vane/issues/678
https://github.com/aristanetworks/vane/issues/677

# List/Attach any dependencies/past issues that are required for this change/provide context
None

# Type of change

- - [x] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 
    
# CI pipeline result

- - [x] Pass
- - [ ] Fail
  
