### PR TITLE
Issue-713:Skip enhancement: nrfu_tests/test_bgp_peers_state.py(NRFU4.2)

### DIFF
--- a/nrfu_tests/test_bgp_peers_state.py
+++ b/nrfu_tests/test_bgp_peers_state.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+# Copyright (c) 2024 Arista Networks, Inc.  All rights reserved.
 # Arista Networks, Inc. Confidential and Proprietary.
 
 """
@@ -56,9 +56,11 @@ class BgpIpPeersStatusTests:
 
             # Skipping, if BGP is not configured.
             if not bgp_peers:
-                pytest.skip(
-                    f"For {tops.dut_name}, BGP is not configured, hence skipped the testcase."
+                tops.output_msg = (
+                    f"Skipping test case on {tops.dut_name} as BGP is not configured on device."
                 )
+                tests_tools.post_process_skip(tops, self.test_bgp_ipv4_peers_state, self.output)
+                pytest.skip(tops.output_msg)
 
             # Failing the test case if BGP peers are not found.
             for vrf in bgp_peers:

--- a/nrfu_tests/test_bgp_peers_state.py
+++ b/nrfu_tests/test_bgp_peers_state.py
@@ -57,7 +57,8 @@ class BgpIpPeersStatusTests:
             # Skipping, if BGP is not configured.
             if not bgp_peers:
                 tops.output_msg = (
-                    f"Skipping test case on {tops.dut_name} as BGP is not configured on device."
+                    f"BGP is not configured on device {tops.dut_name}, hence skipping the test"
+                    " case."
                 )
                 tests_tools.post_process_skip(tops, self.test_bgp_ipv4_peers_state, self.output)
                 pytest.skip(tops.output_msg)

--- a/nrfu_tests/test_definition.yaml.j2
+++ b/nrfu_tests/test_definition.yaml.j2
@@ -135,7 +135,7 @@
       criteria: {{ global_dut_filter.criteria }}
       filter: {{ global_dut_filter.filter }}
     - name: test_bgp_ipv4_peers_state
-      description: Testcases for verification of BGP ipv4 peers are established.
+      description: Testcase for verification of BGP IPv4 peers state.
       test_id: NRFU4.2
       show_cmd: show ip bgp summary vrf all
       expected_output: null


### PR DESCRIPTION




































Skip enhancement: nrfu_tests/test_bgp_peers_state.py(NRFU4.2)

# Please include a summary of the changes

Skip enhancement: nrfu_tests/test_bgp_peers_state.py(NRFU4.2)

# Any specific logic/part of code you need extra attention on

Skip test case with a valid reason and generate both docx and HTML reports correctly.
Updated description change in :  nrfu_tests/test_definition.yaml.j2 file.


# Include the Issue number and link

NRFU4.2
https://github.com/aristanetworks/vane/issues/713

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [ ]  New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [x] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments

Reports:

Testcase will skip if the BGP is not configured on device.


[SKIP-REPORT-NEW.docx](https://github.com/aristanetworks/vane/files/14694345/SKIP-REPORT-NEW.docx)


Testcase is passed on All BGP IPv4 peers are in established state.

[PASS-REPORT-NEW.docx](https://github.com/aristanetworks/vane/files/14694351/PASS-REPORT-NEW.docx)


Html Repots:

[NRFU4.2-PASS-SKIP-NEW.zip](https://github.com/aristanetworks/vane/files/14694364/NRFU4.2-PASS-SKIP-NEW.zip)

