### PR TITLE
668 nrfu66 test system hardware flash free space is broken

### DIFF
--- a/nrfu_tests/test_system_hardware_flash_free_space.py
+++ b/nrfu_tests/test_system_hardware_flash_free_space.py
@@ -70,13 +70,13 @@ class FlashFreeSpaceTests:
             command on dut and verifying that peer supervisor flash file system utilization is
             within the range.
             """
-            output = tops.run_show_cmds([peer_supervisor_cmd])
+            output = tops.run_show_cmds([peer_supervisor_cmd], encoding="txt")
             logging.info(
                 f"On device {tops.dut_name}, output of {peer_supervisor_cmd} command"
                 f" is:\n{output}\n"
             )
             self.output += f"\nOutput of {peer_supervisor_cmd} command is:\n{output}"
-            output = output[0]["result"]["messages"][0].split("\n")
+            output = output[0]["result"]["output"].split("\n")
 
             for line in output:
                 if "bytes total" in line:

--- a/nrfu_tests/test_system_hardware_flash_free_space.py
+++ b/nrfu_tests/test_system_hardware_flash_free_space.py
@@ -67,7 +67,6 @@ class FlashFreeSpaceTests:
             )
             logging.debug(f"Primary flash utilization is: {flash_utilization}")
 
-
             """
             TS: Running `bash timeout 60 FastCli -p15 -c "session peer-supervisor dir flash:"`
             command on dut and verifying that peer supervisor flash file system utilization is
@@ -120,7 +119,8 @@ class FlashFreeSpaceTests:
                             f" actual found as '{utilization}%'.\n"
                         )
 
-        except (AttributeError, LookupError, EapiError, TypeError) as excep:
+        # pylint: disable-next=broad-exception-caught
+        except BaseException as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
                 f"On device {tops.dut_name}, Error while running the test case"

--- a/nrfu_tests/test_system_hardware_flash_free_space.py
+++ b/nrfu_tests/test_system_hardware_flash_free_space.py
@@ -41,6 +41,7 @@ class FlashFreeSpaceTests:
         flash_free = ""
         peer_flash_size = ""
         peer_flash_free = ""
+        peer_flash_utilization = ""
         peer_supervisor_cmd = 'bash timeout 60 FastCli -p15 -c "session peer-supervisor dir flash:"'
         tops.output_msg = "Primary and peer supervisor flash file system utilization is below 70%."
 
@@ -64,30 +65,46 @@ class FlashFreeSpaceTests:
             tops.actual_output["primary_supervisor_flash_utilization_within_range"] = (
                 flash_utilization <= 70
             )
+            logging.debug(f"primary flash utilization is: {flash_utilization}")
 
             """
             TS: Running `bash timeout 60 FastCli -p15 -c "session peer-supervisor dir flash:"`
             command on dut and verifying that peer supervisor flash file system utilization is
             within the range.
             """
-            output = tops.run_show_cmds([peer_supervisor_cmd], encoding="txt")
-            logging.info(
-                f"On device {tops.dut_name}, output of {peer_supervisor_cmd} command"
-                f" is:\n{output}\n"
-            )
-            self.output += f"\nOutput of {peer_supervisor_cmd} command is:\n{output}"
-            output = output[0]["result"]["output"].split("\n")
+            try:
+                output = tops.run_show_cmds([peer_supervisor_cmd], encoding="txt")
+                logging.info(
+                    f"On device {tops.dut_name}, output of {peer_supervisor_cmd} command"
+                    f" is:\n{output}\n"
+                )
+                self.output += f"\nOutput of {peer_supervisor_cmd} command is:\n{output}"
+                output = output[0]["result"]["output"].split("\n")
 
-            for line in output:
-                if "bytes total" in line:
-                    peer_flash_size = line.split(" ")[0]
-                    peer_flash_free = line.split(" ")[3].split("(")[1]
-            peer_flash_utilization = round(
-                100 - int(peer_flash_free) / int(peer_flash_size) * 100, 2
-            )
-            tops.actual_output["peer_supervisor_flash_utilization_within_range"] = (
-                peer_flash_utilization <= 70
-            )
+                for line in output:
+                    if "bytes total" in line:
+                        peer_flash_size = line.split(" ")[0]
+                        peer_flash_free = line.split(" ")[3].split("(")[1]
+                        peer_flash_utilization = round(
+                            100 - int(peer_flash_free) / int(peer_flash_size) * 100, 2
+                        )
+
+                tops.actual_output["peer_supervisor_flash_utilization_within_range"] = (
+                    peer_flash_utilization <= 70
+                )
+                logging.debug(f"Peer flash utilization is: {peer_flash_utilization}")
+
+            except (AttributeError, LookupError, EapiError, AssertionError) as excep:
+                tops.actual_output.pop(
+                    "peer_supervisor_flash_utilization_within_range", "No Key found"
+                )
+                tops.expected_output.pop(
+                    "peer_supervisor_flash_utilization_within_range", "No Key found"
+                )
+                logging.error(
+                    f"On device {tops.dut_name}, Error while running peer supervisor command"
+                    f" is:\n{excep}"
+                )
 
             # Output message formation in case of test case fails.
             if tops.actual_output != tops.expected_output:
@@ -102,7 +119,7 @@ class FlashFreeSpaceTests:
                             f" actual found as '{utilization}%'.\n"
                         )
 
-        except (AttributeError, LookupError, EapiError) as excep:
+        except (AttributeError, LookupError, EapiError, TypeError) as excep:
             tops.output_msg = tops.actual_output = str(excep).split("\n", maxsplit=1)[0]
             logging.error(
                 f"On device {tops.dut_name}, Error while running the test case"

--- a/nrfu_tests/test_system_hardware_flash_free_space.py
+++ b/nrfu_tests/test_system_hardware_flash_free_space.py
@@ -65,7 +65,8 @@ class FlashFreeSpaceTests:
             tops.actual_output["primary_supervisor_flash_utilization_within_range"] = (
                 flash_utilization <= 70
             )
-            logging.debug(f"primary flash utilization is: {flash_utilization}")
+            logging.debug(f"Primary flash utilization is: {flash_utilization}")
+
 
             """
             TS: Running `bash timeout 60 FastCli -p15 -c "session peer-supervisor dir flash:"`


### PR DESCRIPTION
# Please include a summary of the changes

* 668-nrfu66-test_system_hardware_flash_free_space-is-broken

# Any specific logic/part of code you need extra attention on

New try/except block for checking peer supervisor.  If peer command, fails the test case can determine there is no supervisor.

# Include the Issue number and link

NRFU6.6 test_system_hardware_flash_free_space is broken #668

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [x] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

Network services review output
    
# CI pipeline result

- - [x] Pass
- - [ ] Fail
  

