### PR TITLE
Issue-659: Dont print traceback by default

### DIFF
--- a/vane/tests_client.py
+++ b/vane/tests_client.py
@@ -186,6 +186,7 @@ class TestsClient:
             "processes",
             "mark",
             "setup_show",
+            "traceback",
         ]
 
         logging.info("Initialize test parameter values")
@@ -199,6 +200,18 @@ class TestsClient:
         verbose = self.data_model["parameters"]["verbose"]
         logging.info(f"Setting PyTest parameter verbosity (extension: -v) to {verbose}")
         self._set_cmdline_no_input(verbose, "-v")
+
+    def _set_traceback_level(self):
+        """Set python traceback printing level"""
+
+        traceback = self.data_model["parameters"]["traceback"]
+        if traceback:
+            tb_value = "long"
+        else:
+            tb_value = "no"
+
+        logging.info(f"Setting Pytest parameter traceback (extenstion: --tb) to {tb_value}")
+        self.test_parameters.append(f"--tb={tb_value}")
 
     def _set_stdout(self):
         """Set stdout for test run"""
@@ -356,6 +369,7 @@ class TestsClient:
         logging.info("Setting test parameters")
         self._init_parameters()
         self._set_verbosity()
+        self._set_traceback_level()
         self._set_stdout()
         self._set_setup_show()
         self._set_test_cases()


### PR DESCRIPTION
# Please include a summary of the changes
vane/tests_client.py -
Added traceback as parameter in definitions.yaml. The default behavior for traceback is to not print any tracebacks in html reports. To enable traceback printing in html reports, add following line to definitions.yaml file:
traceback: true

# Any specific logic/part of code you need extra attention on

Explain any specific logic you need special attention on

# Include the Issue number and link
Closes #659 
Make sure to link the issue in the github PR UI 

# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [X] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [X] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
Here is the html report without traceback in definitions.yaml: 
[html_report.zip](https://github.com/aristanetworks/vane/files/14766256/html_report.zip)
Here is the html report with trackback set to true in definitions.yaml:
[html_report1.zip](https://github.com/aristanetworks/vane/files/14766262/html_report1.zip)

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ X] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
