### PR TITLE
Issue #658: Add support for only generating summary docx reports

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -51,6 +51,8 @@ max-module-lines=1200
 
 # Maximum number of locals for function / method body.
 max-locals=25
+# Maximum number of class instance attributes
+max-attributes=12
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=1

--- a/tests/unittests/fixtures/definitions_nrfu_custom_expected.yaml
+++ b/tests/unittests/fixtures/definitions_nrfu_custom_expected.yaml
@@ -1,4 +1,5 @@
 parameters:
+  generate_detailed_report: false
   generate_test_definitions: true
   html_report: reports/report
   json_report: reports/report
@@ -19,4 +20,3 @@ parameters:
   test_dirs:
   - sample_network_tests/memory
   verbose: true
-  generate_only_summary_report: true

--- a/tests/unittests/fixtures/definitions_nrfu_custom_expected.yaml
+++ b/tests/unittests/fixtures/definitions_nrfu_custom_expected.yaml
@@ -19,3 +19,4 @@ parameters:
   test_dirs:
   - sample_network_tests/memory
   verbose: true
+  generate_only_summary_report: true

--- a/tests/unittests/fixtures/definitions_nrfu_default_expected.yaml
+++ b/tests/unittests/fixtures/definitions_nrfu_default_expected.yaml
@@ -19,3 +19,4 @@ parameters:
   test_dirs:
   - nrfu_tests
   verbose: true
+  generate_only_summary_report: true

--- a/tests/unittests/fixtures/definitions_nrfu_default_expected.yaml
+++ b/tests/unittests/fixtures/definitions_nrfu_default_expected.yaml
@@ -1,4 +1,5 @@
 parameters:
+  generate_detailed_report: false
   generate_test_definitions: true
   html_report: reports/report
   json_report: reports/report
@@ -19,4 +20,3 @@ parameters:
   test_dirs:
   - nrfu_tests
   verbose: true
-  generate_only_summary_report: true

--- a/tests/unittests/test_nrfu_client.py
+++ b/tests/unittests/test_nrfu_client.py
@@ -111,6 +111,7 @@ def test_ask_report_detail(mocker):
     for idx, input_item in enumerate(inputs):
         mocker.patch("builtins.input", return_value=input_item)
         client.ask_report_detail()
+        # pylint: disable=W0212
         assert client._report_detail_level == outputs[idx]
 
 

--- a/tests/unittests/test_nrfu_client.py
+++ b/tests/unittests/test_nrfu_client.py
@@ -107,12 +107,12 @@ def test_ask_report_detail(mocker):
     # inputs that can be provided by user
     inputs = ["", "y", "yes", "n", "no", "garbage"]
     # desired outputs for above inputs
-    outputs = [True, False, False, True, True, True]
+    outputs = [False, True, True, False, False, False]
     for idx, input_item in enumerate(inputs):
         mocker.patch("builtins.input", return_value=input_item)
         client.ask_report_detail()
         # pylint: disable=W0212
-        assert client._report_detail_level == outputs[idx]
+        assert client._detailed_report == outputs[idx]
 
 
 def test_get_credentials(mocker):

--- a/tests/unittests/test_nrfu_client.py
+++ b/tests/unittests/test_nrfu_client.py
@@ -52,6 +52,7 @@ def test_setup_not_cvp(mocker, capsys):
     mocker.patch("vane.nrfu_client.NrfuClient.not_cvp_application", return_value=([], "cvp"))
     mocker.patch("vane.nrfu_client.NrfuClient.generate_duts_file")
     mocker.patch("vane.nrfu_client.NrfuClient.generate_definitions_file")
+    mocker.patch("vane.nrfu_client.NrfuClient.ask_report_detail")
 
     # Create an instance of the NrfuClient class
     client = nrfu_client.NrfuClient()
@@ -79,6 +80,7 @@ def test_setup_cvp(mocker, capsys):
     mocker.patch("vane.nrfu_client.NrfuClient.cvp_application", return_value=([], "noncvp"))
     mocker.patch("vane.nrfu_client.NrfuClient.generate_duts_file")
     mocker.patch("vane.nrfu_client.NrfuClient.generate_definitions_file")
+    mocker.patch("vane.nrfu_client.NrfuClient.ask_report_detail")
 
     # Create an instance of the NrfuClient class
     client = nrfu_client.NrfuClient()
@@ -96,6 +98,19 @@ def test_setup_cvp(mocker, capsys):
     client.generate_duts_file.assert_called_once()
     client.generate_definitions_file.assert_called_once()
 
+def test_ask_report_detail(mocker):
+    """Testing the functionality to ask report details"""
+
+    mocker.patch("vane.nrfu_client.NrfuClient.setup")
+    client = nrfu_client.NrfuClient()
+    #inputs that can be provided by user
+    inputs = ["", "y", "yes", "n", "no", "garbage"]
+    #desired outputs for above inputs
+    outputs = [True, False, False, True, True, True]
+    for idx, input_item in enumerate(inputs):
+        mocker.patch("builtins.input", return_value=input_item)
+        client.ask_report_detail()
+        assert client._report_detail_level == outputs[idx]
 
 def test_get_credentials(mocker):
     """Testing the functionality to save username/passwords"""

--- a/tests/unittests/test_nrfu_client.py
+++ b/tests/unittests/test_nrfu_client.py
@@ -98,19 +98,21 @@ def test_setup_cvp(mocker, capsys):
     client.generate_duts_file.assert_called_once()
     client.generate_definitions_file.assert_called_once()
 
+
 def test_ask_report_detail(mocker):
     """Testing the functionality to ask report details"""
 
     mocker.patch("vane.nrfu_client.NrfuClient.setup")
     client = nrfu_client.NrfuClient()
-    #inputs that can be provided by user
+    # inputs that can be provided by user
     inputs = ["", "y", "yes", "n", "no", "garbage"]
-    #desired outputs for above inputs
+    # desired outputs for above inputs
     outputs = [True, False, False, True, True, True]
     for idx, input_item in enumerate(inputs):
         mocker.patch("builtins.input", return_value=input_item)
         client.ask_report_detail()
         assert client._report_detail_level == outputs[idx]
+
 
 def test_get_credentials(mocker):
     """Testing the functionality to save username/passwords"""

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -54,7 +54,7 @@ class NrfuClient:
         self.duts_file = "nrfu_tests/duts_nrfu.yaml"
         self.username = ""
         self.password = ""
-        self._report_detail_level = True # only summary report by default
+        self._report_detail_level = True  # only summary report by default
 
         logging.info("Starting the NRFU client")
         self.setup()
@@ -94,13 +94,15 @@ class NrfuClient:
         print("\x1b[32mStarting Execution of NRFU tests via Vane\x1b[0m")
 
     def ask_report_detail(self):
-        """ Ask user if summary or detailed report 
+        """Ask user if summary or detailed report
         Puts the user's choice in self._report_detail_level
         """
-        self._report_detail_level = True # default only summary report
-        user_choice = input("Do you want detailed report?(Press enter for Default: no) [y/yes/n/no]:")
-        if user_choice and user_choice in ['y', 'yes']:
-            self._report_detail_level = False # summary + detailed report
+        self._report_detail_level = True  # default only summary report
+        user_choice = input(
+            "Do you want detailed report?(Press enter for Default: no) [y/yes/n/no]:"
+        )
+        if user_choice and user_choice in ["y", "yes"]:
+            self._report_detail_level = False  # summary + detailed report
 
     def get_credentials(self):
         """Ask user to enter credentials for EOS/CloudVision

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -99,7 +99,7 @@ class NrfuClient:
         """
         self._report_detail_level = True  # default set to generate only summary report
         user_choice = input(
-            "Do you want detailed report?(Press enter for Default: no) [y/yes/n/no]:"
+            "Do you want detailed report?(Press Enter for the default option: "No") [y/yes/n/no]:"
         )
         if user_choice and user_choice in ["y", "yes"]:
             self._report_detail_level = False  # summary + detailed report

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -67,6 +67,7 @@ class NrfuClient:
         # Configure readline to enable arrow key navigation
         readline.parse_and_bind("set editing-mode vi")  # Use 'vi' mode for navigation
 
+        self.ask_report_detail()
         # Getting credentials from user
         self.get_credentials()
 
@@ -88,6 +89,15 @@ class NrfuClient:
 
         # Run Vane with the generated duts and definitions file
         print("\x1b[32mStarting Execution of NRFU tests via Vane\x1b[0m")
+
+    def ask_report_detail(self):
+        """ Ask user if summary or detailed report 
+        Puts the user's choice in self._report_detail_level
+        """
+        self._report_detail_level = True #only summary report
+        user_choice = input("Do you want detailed report?[Default: no] (y/n/yes/no)")
+        if user_choice and user_choice in ['y', 'yes']:
+            self._report_detail_level = False #summary + detailed report
 
     def get_credentials(self):
         """Ask user to enter credentials for EOS/CloudVision
@@ -292,6 +302,7 @@ class NrfuClient:
                 "test_definitions": "test_definition.yaml",
                 "report_summary_style": "modern",
                 "self_contained": True,
+                "generate_only_summary_report": self._report_detail_level,
             }
         }
 

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -54,7 +54,7 @@ class NrfuClient:
         self.duts_file = "nrfu_tests/duts_nrfu.yaml"
         self.username = ""
         self.password = ""
-        self._report_detail_level = True  # only summary report by default
+        self._report_detail_level = True  # generate only summary report by default
 
         logging.info("Starting the NRFU client")
         self.setup()

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -54,7 +54,7 @@ class NrfuClient:
         self.duts_file = "nrfu_tests/duts_nrfu.yaml"
         self.username = ""
         self.password = ""
-        self._report_detail_level = True  # generate only summary report by default
+        self._detailed_report = False  # generate only summary report by default
 
         logging.info("Starting the NRFU client")
         self.setup()
@@ -97,12 +97,14 @@ class NrfuClient:
         """Ask user if summary or detailed report
         Puts the user's choice in self._report_detail_level
         """
-        self._report_detail_level = True  # default set to generate only summary report
+        self._detailed_report = False  # default set to generate only summary report
         user_choice = input(
-            "Do you want detailed report?(Press Enter for the default option: "No") [y/yes/n/no]:"
+            "Do you want detailed report?(Anything other than y/yes defaults to 'no') [y/yes/n/no]:"
         )
         if user_choice and user_choice in ["y", "yes"]:
-            self._report_detail_level = False  # summary + detailed report
+            self._detailed_report = True  # summary + detailed report
+        else:
+            print("You did not input 'y/yes/n/no', defaulting to 'no'.")
 
     def get_credentials(self):
         """Ask user to enter credentials for EOS/CloudVision
@@ -291,6 +293,7 @@ class NrfuClient:
                 "html_report": "reports/report",
                 "json_report": "reports/report",
                 "generate_test_definitions": True,
+                "generate_detailed_report": self._detailed_report,
                 "master_definitions": "nrfu_tests/master_def.yaml",
                 "mark": None,
                 "processes": None,
@@ -307,7 +310,6 @@ class NrfuClient:
                 "test_definitions": "test_definition.yaml",
                 "report_summary_style": "modern",
                 "self_contained": True,
-                "generate_only_summary_report": self._report_detail_level,
             }
         }
 

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -97,7 +97,7 @@ class NrfuClient:
         """Ask user if summary or detailed report
         Puts the user's choice in self._report_detail_level
         """
-        self._report_detail_level = True  # default only summary report
+        self._report_detail_level = True  # default set to generate only summary report
         user_choice = input(
             "Do you want detailed report?(Press enter for Default: no) [y/yes/n/no]:"
         )

--- a/vane/nrfu_client.py
+++ b/vane/nrfu_client.py
@@ -54,6 +54,7 @@ class NrfuClient:
         self.duts_file = "nrfu_tests/duts_nrfu.yaml"
         self.username = ""
         self.password = ""
+        self._report_detail_level = True # only summary report by default
 
         logging.info("Starting the NRFU client")
         self.setup()
@@ -67,7 +68,6 @@ class NrfuClient:
         # Configure readline to enable arrow key navigation
         readline.parse_and_bind("set editing-mode vi")  # Use 'vi' mode for navigation
 
-        self.ask_report_detail()
         # Getting credentials from user
         self.get_credentials()
 
@@ -80,6 +80,9 @@ class NrfuClient:
             device_data, source = self.cvp_application()
         else:
             device_data, source = self.not_cvp_application()
+
+        # Ask the level of report details
+        self.ask_report_detail()
 
         # Generate duts_nrfu.yaml file from the duts data gathered above
         self.generate_duts_file(device_data, source)
@@ -94,10 +97,10 @@ class NrfuClient:
         """ Ask user if summary or detailed report 
         Puts the user's choice in self._report_detail_level
         """
-        self._report_detail_level = True #only summary report
-        user_choice = input("Do you want detailed report?[Default: no] (y/n/yes/no)")
+        self._report_detail_level = True # default only summary report
+        user_choice = input("Do you want detailed report?(Press enter for Default: no) [y/yes/n/no]:")
         if user_choice and user_choice in ['y', 'yes']:
-            self._report_detail_level = False #summary + detailed report
+            self._report_detail_level = False # summary + detailed report
 
     def get_credentials(self):
         """Ask user to enter credentials for EOS/CloudVision

--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -110,6 +110,7 @@ class ReportClient:
 
         self._reports_dir = self.data_model["parameters"]["report_dir"]
         _results_dir = self.data_model["parameters"]["results_dir"]
+        self._only_summary_report = self.data_model["parameters"]["generate_only_summary_report"]
         self._results_datamodel = None
         self._compile_yaml_data(_results_dir)
         logging.debug(f"Results file data is {self._results_datamodel}")
@@ -226,7 +227,8 @@ class ReportClient:
         self._write_toc_page()
         self._write_summary_report()
         self._write_tests_case_report()
-        self._write_detail_report()
+        if not self._only_summary_report:
+            self._write_detail_report()
 
         _, file_date = return_date()
         reports_dir = self._reports_dir

--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -110,8 +110,8 @@ class ReportClient:
 
         self._reports_dir = self.data_model["parameters"]["report_dir"]
         _results_dir = self.data_model["parameters"]["results_dir"]
-        self._only_summary_report = self.data_model["parameters"].get(
-            "generate_only_summary_report", True
+        self._need_detailed_report = self.data_model["parameters"].get(
+            "generate_detailed_report", False  # If not specified, generate only summary
         )
         self._results_datamodel = None
         self._compile_yaml_data(_results_dir)
@@ -229,7 +229,7 @@ class ReportClient:
         self._write_toc_page()
         self._write_summary_report()
         self._write_tests_case_report()
-        if not self._only_summary_report:
+        if self._need_detailed_report:
             self._write_detail_report()
 
         _, file_date = return_date()

--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -110,7 +110,7 @@ class ReportClient:
 
         self._reports_dir = self.data_model["parameters"]["report_dir"]
         _results_dir = self.data_model["parameters"]["results_dir"]
-        self._only_summary_report = self.data_model["parameters"]["generate_only_summary_report"]
+        self._only_summary_report = self.data_model["parameters"].get("generate_only_summary_report", True)
         self._results_datamodel = None
         self._compile_yaml_data(_results_dir)
         logging.debug(f"Results file data is {self._results_datamodel}")

--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -110,7 +110,9 @@ class ReportClient:
 
         self._reports_dir = self.data_model["parameters"]["report_dir"]
         _results_dir = self.data_model["parameters"]["results_dir"]
-        self._only_summary_report = self.data_model["parameters"].get("generate_only_summary_report", True)
+        self._only_summary_report = self.data_model["parameters"].get(
+            "generate_only_summary_report", True
+        )
         self._results_datamodel = None
         self._compile_yaml_data(_results_dir)
         logging.debug(f"Results file data is {self._results_datamodel}")


### PR DESCRIPTION
# Please include a summary of the changes

* nrfu_client.py - ask whether user wants detailed report
* report_client.py - depending on `generate_only_summary_report` in definitions.yml - generate only summary docx reports

# Any specific logic/part of code you need extra attention on
None
Explain any specific logic you need special attention on
N/A
# Include the Issue number and link
closes #658 


# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [ ] Bug fix (non-breaking change which fixes an issue)
- - [x] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [x] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?
- Unit tested
- Tested functionality with `vane --nrfu` option and with just plain `vane` too
Summary report - 
[report_2404060737.docx](https://github.com/aristanetworks/vane/files/14893707/report_2404060737.docx)
Detailed report -
[report_2404060738.docx](https://github.com/aristanetworks/vane/files/14893710/report_2404060738.docx)

## Bug fix

    Include before and after snapshots/screenshots/changed logs
    
## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [x] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update
   - Might need documentation update
    If applicable, ensure documentation has been updated for ReadMe, Getting Started guide, and Style guide
    
# Additional comments
