### PR TITLE
Handle graceful Vane exit when no devices are selected to run Vane tests

### DIFF
--- a/vane/report_client.py
+++ b/vane/report_client.py
@@ -518,21 +518,21 @@ class ReportClient:
             testcase_results (dict): Data structure with test case results
             report_template (dict): Data structure describing reports fields
         """
+
+        if not testcase_results:
+            logging.warning(
+                "Vane ran no test cases against DUTS. Skipping the custom testcase report"
+            )
+            return
+
         columns = len(summary_headers)
         rows = len(testcase_results) + 1
         table = CachedTable.transform(
             self._document.add_table(rows=rows, cols=columns, style="Table Grid")
         )
 
-        if testcase_results:
-            self._create_header_row(table, summary_headers, report_template)
-            self._create_data_row(table, testcase_results, report_template)
-        else:
-            logging.error("Vane ran no test cases against DUTS")
-            print(
-                "Vane ran no test cases against DUTs.  Check your duts.yml file and test case "
-                "filters"
-            )
+        self._create_header_row(table, summary_headers, report_template)
+        self._create_data_row(table, testcase_results, report_template)
 
     def _create_header_row(self, table, summary_headers, report_template):
         """Writes header row within Word doc table


### PR DESCRIPTION
Fixed bug : #742 

# Please include a summary of the changes

* report_client.py: added logic to not continue when there are no test_case results. This was being handled for default test case reports but not for custom test case reports


# Include the Issue number and link
#742 


# Type of change

- - [X] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [X] Easy
- - [ ] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix

BEFORE:
<img width="1300" alt="Screenshot 2024-04-05 at 11 55 19 AM" src="https://github.com/aristanetworks/vane/assets/123415500/fd1bcad9-bd00-4ff8-a1e6-f3048cbbccc5">
AFTER
<img width="1337" alt="Screenshot 2024-04-12 at 10 46 33 AM" src="https://github.com/aristanetworks/vane/assets/123415500/0326b22e-8c7a-4ff1-b9ee-e2cfe2e527b5">

<img width="1333" alt="Screenshot 2024-04-12 at 10 45 01 AM" src="https://github.com/aristanetworks/vane/assets/123415500/3aefbf35-73bc-43a9-b8b8-5b38933c6bfd">

    
# CI pipeline result

- - [X] Pass
- - [ ] Fail
  