### PR TITLE
Issue_638: Added fix for XML character in the command output.

### DIFF
--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1085,11 +1085,26 @@ class TestOps:
         if len(self._show_cmds[self.dut_name]) > 0 and self.dut:
             self._verify_show_cmd(self._show_cmds[self.dut_name], self.dut)
             if self.show_cmd:
-                self.show_cmd_txt = self.dut["output"][self.show_cmd]["text"]
+                text_output = self.dut["output"][self.show_cmd]["text"]
+                # Added check to validate the xml characters from the command output.
+                formatted_output = "".join(
+                    char for char in text_output if valid_xml_char_ordinal(char)
+                )
+                self.show_cmd_txt = formatted_output
             for show_cmd in self.show_cmds[self.dut_name]:
-                self.show_cmd_txts[self.dut_name].append(self.dut["output"][show_cmd]["text"])
+                text_output = self.dut["output"][show_cmd]["text"]
+                # Added check to validate the xml characters from the command output.
+                formatted_output = "".join(
+                    char for char in text_output if valid_xml_char_ordinal(char)
+                )
+                self.show_cmd_txts[self.dut_name].append(formatted_output)
             for show_cmd in self._show_cmds[self.dut_name]:
-                self._show_cmd_txts[self.dut_name].append(self.dut["output"][show_cmd]["text"])
+                text_output = self.dut["output"][show_cmd]["text"]
+                # Added check to validate the xml characters from the command output.
+                formatted_output = "".join(
+                    char for char in text_output if valid_xml_char_ordinal(char)
+                )
+                self._show_cmd_txts[self.dut_name].append(formatted_output)
 
         self.comment = ""
         self.output_msg = ""
@@ -1270,14 +1285,6 @@ class TestOps:
 
         print("\n\nSHOW OUTPUT COLLECTED IN TEST CASE:")
         print("===================================")
-
-        text_outputs = {}
-        for device, cmd_output in self._show_cmd_txts.items():
-            text_outputs[device] = []
-            for text_output in cmd_output:
-                output = "".join(char for char in text_output if valid_xml_char_ordinal(char))
-                text_outputs[device].append(output)
-        self._show_cmd_txts = text_outputs
 
         for dut_index, (dut_name, _show_cmds) in enumerate(self._show_cmds.items(), start=1):
             for cmd_index, (command, text) in enumerate(

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1271,6 +1271,14 @@ class TestOps:
         print("\n\nSHOW OUTPUT COLLECTED IN TEST CASE:")
         print("===================================")
 
+        text_outputs = {}
+        for device, cmd_output in self._show_cmd_txts.items():
+            text_outputs[device] = []
+            for text_output in cmd_output:
+                output = "".join(char for char in text_output if valid_xml_char_ordinal(char))
+                text_outputs[device].append(output)
+        self._show_cmd_txts = text_outputs
+
         for dut_index, (dut_name, _show_cmds) in enumerate(self._show_cmds.items(), start=1):
             for cmd_index, (command, text) in enumerate(
                 zip(_show_cmds, self._show_cmd_txts[dut_name]), start=1
@@ -1792,3 +1800,20 @@ class TestOps:
             # Updating the commands and command output dictionaries.
             self._show_cmds[device_name].extend(cmds)
             self._show_cmd_txts[device_name].extend(cmds_output)
+
+
+def valid_xml_char_ordinal(char):
+    """
+    Utility to filter the string as per XML standard
+    Args:
+        char(ste): characters to filter out
+    Return:
+        str: Filtered string
+    """
+    codepoint = ord(char)
+    return (
+        0x20 <= codepoint <= 0xD7FF
+        or codepoint in (0x9, 0xA, 0xD)
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    )

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1815,7 +1815,7 @@ class TestOps:
 
     def get_cmd_output_from_device_details(self, command):
         """
-        Utility to get the command output of the command mentioned in arguments.
+        Utility to get the output of the command mentioned in arguments.
         Args:
             command(str): Command to collect the output from device output details.
         Return:

--- a/vane/tests_tools.py
+++ b/vane/tests_tools.py
@@ -1085,25 +1085,13 @@ class TestOps:
         if len(self._show_cmds[self.dut_name]) > 0 and self.dut:
             self._verify_show_cmd(self._show_cmds[self.dut_name], self.dut)
             if self.show_cmd:
-                text_output = self.dut["output"][self.show_cmd]["text"]
-                # Added check to validate the xml characters from the command output.
-                formatted_output = "".join(
-                    char for char in text_output if valid_xml_char_ordinal(char)
-                )
+                formatted_output = self.get_cmd_output_from_device_details(self.show_cmd)
                 self.show_cmd_txt = formatted_output
             for show_cmd in self.show_cmds[self.dut_name]:
-                text_output = self.dut["output"][show_cmd]["text"]
-                # Added check to validate the xml characters from the command output.
-                formatted_output = "".join(
-                    char for char in text_output if valid_xml_char_ordinal(char)
-                )
+                formatted_output = self.get_cmd_output_from_device_details(show_cmd)
                 self.show_cmd_txts[self.dut_name].append(formatted_output)
             for show_cmd in self._show_cmds[self.dut_name]:
-                text_output = self.dut["output"][show_cmd]["text"]
-                # Added check to validate the xml characters from the command output.
-                formatted_output = "".join(
-                    char for char in text_output if valid_xml_char_ordinal(char)
-                )
+                formatted_output = self.get_cmd_output_from_device_details(show_cmd)
                 self._show_cmd_txts[self.dut_name].append(formatted_output)
 
         self.comment = ""
@@ -1808,19 +1796,34 @@ class TestOps:
             self._show_cmds[device_name].extend(cmds)
             self._show_cmd_txts[device_name].extend(cmds_output)
 
+    def valid_xml_char_ordinal(self, char):
+        """
+        Utility to filter the string as per XML standard
+        Args:
+            char(ste): characters to filter out
+        Return:
+            str: Filtered string
+        """
 
-def valid_xml_char_ordinal(char):
-    """
-    Utility to filter the string as per XML standard
-    Args:
-        char(ste): characters to filter out
-    Return:
-        str: Filtered string
-    """
-    codepoint = ord(char)
-    return (
-        0x20 <= codepoint <= 0xD7FF
-        or codepoint in (0x9, 0xA, 0xD)
-        or 0xE000 <= codepoint <= 0xFFFD
-        or 0x10000 <= codepoint <= 0x10FFFF
-    )
+        codepoint = ord(char)
+        return (
+            0x20 <= codepoint <= 0xD7FF
+            or codepoint in (0x9, 0xA, 0xD)
+            or 0xE000 <= codepoint <= 0xFFFD
+            or 0x10000 <= codepoint <= 0x10FFFF
+        )
+
+    def get_cmd_output_from_device_details(self, command):
+        """
+        Utility to get the command output of the command mentioned in arguments.
+        Args:
+            command(str): Command to collect the output from device output details.
+        Return:
+            str: Filtered output string
+        """
+
+        output = self.dut["output"][command]["text"]
+        # Added check to validate the xml characters from the command output.
+        formatted_output = "".join(char for char in output if self.valid_xml_char_ordinal(char))
+
+        return formatted_output


### PR DESCRIPTION
# Please include a summary of the changes

* vane/tests_tools.py - Updated file with a utils to validate a XML character, 

# Any specific logic/part of code you need extra attention on
 

- Added utils to validate the XML characters in the command output
- Added check to format the command output first and then pass it for evidence section of docx report.

# Include the Issue number and link

Make sure to link the issue in the github PR UI 
#638 
# List/Attach any dependencies/past issues that are required for this change/provide context

# Type of change

- - [x] Bug fix (non-breaking change which fixes an issue)
- - [ ] New feature (non-breaking change which adds functionality)
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- - [ ] This change requires a documentation update
- - [ ] Other (please specify)

# Effort required on reviewers end

- - [ ] Easy
- - [x] Medium
- - [ ] Hard 

# How Has This Been Tested?

## Bug fix
  Note: Tested all the reports with hardcoded output.
   **Reports before adding the fix for the invalid characters in the command output**    
   
[Before_invalid_xml_character_fix.zip](https://github.com/user-attachments/files/15955954/Before_invalid_xml_character_fix.zip)


<img width="878" alt="before_fix_xml_characters" src="https://github.com/aristanetworks/vane/assets/96573243/45a2c37c-d399-4900-912d-610535dc3ccf">

   **Reports after adding the fix for invalid characters in the command output**    
     
[After_invalid_xml_character_fix.zip](https://github.com/user-attachments/files/15956209/After_invalid_xml_character_fix.zip)
 
<img width="690" alt="image" src="https://github.com/aristanetworks/vane/assets/96573243/520372a9-2923-4a9f-a4be-ffeae81a220e">

## New feature

    Ensure current test cases pass and include newer test cases if required
    
# CI pipeline result

- - [ ] Pass
- - [ ] Fail
  
  If it fails, explain the reason and whether or not we should ignore the failure
  
# Verify Documentation Update

If applicable, ensure changes to [official documentation](http://vane.arista.com/) are included in the PR by following the steps below:

(1) You can locally make required documentation changes within the [docs](https://github.com/aristanetworks/vane/tree/develop/docs) folder and test them by following these steps:

- `mike deploy test`(or any name you want for the local changes version)
- `mike serve`
  (you will be able to view `test` as an option in the version dropdown)
- Once you have ensured the changes are accurate, execute `mike delete test`(this ensures you do not have any local  version branches which do not exist on gh-pages in the github repo).  

(2) Ensure you have [pre-commit hook](https://pre-commit.com/) installed which will take care of linting checks for documentation before you commit your changes.

(3) Lastly ensure the following jobs pass when you create the PR. These jobs ensure that the changes within your PR do not break the documentation.

- Documentation Testing / Run pre-commit validation hooks (pull_request) 
- Documentation Testing / Build site with no warnings (pull_request)  
   

    
# Additional comments
